### PR TITLE
Improve vimrc: fix mapping conflicts and add modern features

### DIFF
--- a/vim/.vimrc
+++ b/vim/.vimrc
@@ -1,5 +1,11 @@
 set history=500
 set autoread
+" Better completion and command line
+set wildmenu
+set wildmode=longest:full,full
+" Better splitting behavior
+set splitbelow
+set splitright
 set hlsearch
 set incsearch
 " by default, case insensitive search
@@ -106,13 +112,13 @@ nnoremap "*p :let @"=substitute(system("wl-paste --no-newline --primary"), '<C-v
 nnoremap H :tabprevious<cr>
 nnoremap L :tabnext<cr>
 nnoremap <C-n> :tabnew<cr>
-nnoremap <C-k> :close<cr>
+nnoremap <leader>k :close<cr>
 nnoremap \ :Texplore<cr>
 nnoremap <leader><Esc> :nohlsearch<cr>
 vnoremap > >gv
 vnoremap < <gv
 tnoremap <leader><Esc><Esc> <C-\><C-n>
-nnoremap <C-_> :terminal
+nnoremap <C-_> :terminal<cr>
 
 " grep
 nnoremap <leader>q :copen<cr>


### PR DESCRIPTION
## Changes Made

### Bug Fixes
- Fix C-k mapping conflict: Changed close window mapping from Ctrl-k to Space-k to avoid conflict with quickfix navigation
- Fix incomplete terminal command: Added missing enter key to terminal mapping so it actually executes

### Improvements  
- Better command completion: Added wildmenu and wildmode for enhanced tab completion in command mode
- Intuitive window splitting: Added splitbelow and splitright for more natural split behavior

### New Keybindings
- Space+k = close window (was Ctrl+k)
- Ctrl+k = previous quickfix item (unchanged)  
- Ctrl+_ = open terminal (now works properly)

These changes fix actual bugs while adding useful modern Vim features that improve the daily workflow.