### PR TITLE
fix: tmux.conf hardcoded path, dead terminal setting, duplicate base-index

### DIFF
--- a/tmux/linux/.tmux.conf
+++ b/tmux/linux/.tmux.conf
@@ -26,9 +26,6 @@ setw -g mode-keys vi
 # mouse behavior
 setw -g mouse on
 
-# vim color scheme need xterm-256color
-set -g default-terminal "xterm-256color"
-set-option -ga terminal-overrides ",xterm-256color:Tc"
 bind-key : command-prompt
 bind-key r refresh-client
 bind-key L clear-history
@@ -108,15 +105,14 @@ set -g default-terminal "tmux-256color"
 set -sa terminal-features ',xterm-256color:RGB'
 set -sa terminal-overrides ',xterm-256color:Tc'
 
-# Start windows and panes at 1, not 0
-set -g base-index 1
+# Pane base index (windows already set to 1 above)
 setw -g pane-base-index 1
 
 # Renumber windows when one is closed
 set -g renumber-windows on
 
 # CCB script directory
-set -g @ccb_bin_dir "/home/stan/.local/bin"
+set -g @ccb_bin_dir "$HOME/.local/bin"
 
 # Better scroll speed (2 lines per scroll instead of default 5)
 bind -T copy-mode-vi WheelUpPane select-pane \; send-keys -X -N 2 scroll-up


### PR DESCRIPTION
## Summary

Three issues found during audit of recent commits to `tmux/linux/.tmux.conf`.

- **Info leak / portability**: `set -g @ccb_bin_dir "/home/stan/.local/bin"` hardcodes a username and breaks on any other machine → replaced with `$HOME/.local/bin`
- **Dead code / conflict**: `set -g default-terminal "xterm-256color"` near the top is overridden later by `tmux-256color` (which is correct for modern setups) — removed the dead line and its stale comment + the now-redundant `terminal-overrides` that's also covered at the bottom
- **Duplicate setting**: `set -g base-index 1` appeared twice; removed the second occurrence (kept `setw -g pane-base-index 1` which was new)

## Test plan

- [ ] `tmux source ~/.tmux.conf` — no errors
- [ ] Open a new tmux session and confirm windows start at index 1
- [ ] Confirm true-color works (`tmux info | grep Tc`)
- [ ] Verify `@ccb_bin_dir` resolves correctly for any plugin that uses it