### PR TITLE
fix: restore NixOS support in linux setup scripts + fix state-file heredoc

### DIFF
--- a/linux/lib/common.sh
+++ b/linux/lib/common.sh
@@ -85,7 +85,7 @@ detect_package_manager() {
         echo "pacman"
     elif command_exists dnf; then
         echo "dnf"
-    elif command_exists nix; then
+    elif command_exists nix-env && command_exists nix-channel; then
         echo "nix"
     else
         echo "unknown"
@@ -107,6 +107,9 @@ update_system() {
             ;;
         dnf)
             sudo dnf check-update || true
+            ;;
+        nix)
+            nix-channel --update
             ;;
         *)
             print_warning "Unknown package manager"
@@ -130,6 +133,9 @@ install_packages() {
             ;;
         dnf)
             sudo dnf install -y "$@"
+            ;;
+        nix)
+            nix-env -iA "${@/#/nixpkgs.}"
             ;;
         *)
             print_error "Unknown package manager"
@@ -250,7 +256,7 @@ get_installed_components() {
     fi
 
     if command_exists python3; then
-        python3 << 'EOF'
+        python3 << EOF
 import json
 
 try:

--- a/linux/setup/basic-packages.sh
+++ b/linux/setup/basic-packages.sh
@@ -31,6 +31,22 @@ install_basic_packages() {
                 ripgrep
             sudo dnf group install -y development-tools
             ;;
+        nix)
+            print_info "Detecting NixOS, using nixpkgs attribute names"
+            nix-env -iA \
+                nixpkgs.curl \
+                nixpkgs.git \
+                nixpkgs.zsh \
+                nixpkgs.tmux \
+                nixpkgs.fd \
+                nixpkgs.gh \
+                nixpkgs.tree \
+                nixpkgs.wl-clipboard \
+                nixpkgs.cmake \
+                nixpkgs.fzf \
+                nixpkgs.ripgrep \
+                nixpkgs.nettools
+            ;;
         *)
             install_packages \
                 curl \

--- a/linux/system/upgrade-packages.sh
+++ b/linux/system/upgrade-packages.sh
@@ -32,6 +32,13 @@ upgrade_packages() {
             sudo dnf upgrade -y
             print_success "DNF packages upgraded successfully"
             ;;
+        nix)
+            print_info "Updating nix channels..."
+            nix-channel --update
+            print_info "Upgrading nix packages..."
+            nix-env -u '*'
+            print_success "Nix packages upgraded successfully"
+            ;;
         *)
             print_error "Unknown package manager"
             return 1


### PR DESCRIPTION
## Problem

PR #19 claimed to add NixOS support to the linux setup scripts, but examining the merged master reveals that the core functionality never landed — likely lost during the manual merge commits. On a NixOS system today:

- `detect_package_manager()` correctly returns `"nix"`
- but `update_system()`, `install_packages()`, `basic-packages.sh`, and `upgrade-packages.sh` all fall through to the error/warning branch → NixOS setup is completely broken despite #19 being merged

Additionally, `get_installed_components()` in `common.sh` used a single-quoted heredoc (`<< 'EOF'`), which prevents shell variable expansion. `$STATE_FILE` was passed literally to Python instead of the actual path, so `./setup.sh status` always produced empty output silently.

## Changes

### `linux/lib/common.sh`
- `detect_package_manager()`: check for `nix-env` AND `nix-channel` instead of just `nix`, matching the intent of the fix commit in #19 (avoids mis-classifying non-NixOS systems that merely have the `nix` binary installed)
- `update_system()`: add `nix)` case → `nix-channel --update`
- `install_packages()`: add `nix)` case → `nix-env -iA` with `nixpkgs.` prefix applied to each argument via `${@/#/nixpkgs.}`
- `get_installed_components()`: change `<< 'EOF'` to `<< EOF` so `$STATE_FILE` expands to the real path

### `linux/setup/basic-packages.sh`
- Add `nix)` case with correct nixpkgs attribute names (`fd` not `fd-find`, `nettools` not `net-tools`, `gh`, etc.)

### `linux/system/upgrade-packages.sh`
- Add `nix)` case → `nix-channel --update` then `nix-env -u '*'`

## Test plan
- [ ] On NixOS: `./setup.sh basic` installs packages via `nix-env -iA nixpkgs.*`
- [ ] On NixOS: `./setup.sh upgrade` runs channel update then `nix-env -u '*'`
- [ ] On apt/pacman/dnf system: no behavior change
- [ ] `./setup.sh status` now prints the component table (was silently empty before)
