### PR TITLE
fix: add existence checks for atuin and starship init in config.nu

### DIFF
--- a/home-chezmoi/private_Library/private_Application Support/nushell/config.nu
+++ b/home-chezmoi/private_Library/private_Application Support/nushell/config.nu
@@ -1,8 +1,12 @@
 # atuin
-# run these for the first time
-mkdir ~/.local/share/atuin/
-atuin init nu | save -f ~/.local/share/atuin/init.nu
+if not ("~/.local/share/atuin/init.nu" | path expand | path exists) {
+    mkdir ~/.local/share/atuin/
+    atuin init nu | save -f ~/.local/share/atuin/init.nu
+}
 source ~/.local/share/atuin/init.nu
+
 # starship
-mkdir ($nu.data-dir | path join "vendor/autoload")
-starship init nu | save -f ($nu.data-dir | path join "vendor/autoload/starship.nu")
+if not (($nu.data-dir | path join "vendor/autoload/starship.nu") | path exists) {
+    mkdir ($nu.data-dir | path join "vendor/autoload")
+    starship init nu | save -f ($nu.data-dir | path join "vendor/autoload/starship.nu")
+}


### PR DESCRIPTION
Only generate init scripts if they don't already exist, avoiding subprocess overhead on every nushell startup.

Closes #25

Generated with [Claude Code](https://claude.ai/code)