### PR TITLE
fix: remove leaked GitHub PAT, fix chmod 777, add missing ;; in nix case

### DIFF
--- a/hpc/.bashrc
+++ b/hpc/.bashrc
@@ -6,7 +6,7 @@ if [ -f /etc/bashrc ]; then
 fi
 
 # User specific environment
-if ! [[ "$PATH" =~ "$HOME/.local/bin:$HOME/bin:" ]]
+if ! [[  "$PATH" =~ "$HOME/.local/bin:$HOME/bin:" ]]
 then
     PATH="$HOME/.local/bin:$HOME/bin:$PATH"
 fi
@@ -62,7 +62,7 @@ cat > $user_home/Desktop/.scripts/matlab << 'EOF'
 module load matlab/R2024b
 matlab -desktop
 EOF
-chmod 777 $user_home/Desktop/.scripts/matlab
+chmod 755 $user_home/Desktop/.scripts/matlab
 if [ -f $user_home/Desktop/matlab.desktop ]; then
 	rm $user_home/Desktop/matlab.desktop
 fi
@@ -75,7 +75,7 @@ Exec=/home/$USER/Desktop/.scripts/matlab
 Icon=/home/$USER/Desktop/.icons/matlab.png
 Terminal=false
 EOF
-chmod 777 $user_home/Desktop/matlab.desktop
+chmod 755 $user_home/Desktop/matlab.desktop
 
 # rstudio
 if [ ! -f $user_home/Desktop/.scripts/rstudio ]; then
@@ -94,7 +94,7 @@ export PATH=/home/zyyu/.conda/envs/hpc/bin:$PATH
 export LD_LIBRARY_PATH="/home/zyyu/.conda/envs/hpc/lib/R/lib:/home/zyyu/.conda/envs/hpc/lib:${LD_LIBRARY_PATH}" 
 exec rstudio
 EOF
-chmod 777 $user_home/Desktop/.scripts/rstudio
+chmod 755 $user_home/Desktop/.scripts/rstudio
 if [ -f $user_home/Desktop/rstudio.desktop ]; then
 	rm $user_home/Desktop/rstudio.desktop
 fi
@@ -107,7 +107,7 @@ Exec=/home/$USER/Desktop/.scripts/rstudio
 Icon=/home/$USER/Desktop/.icons/rstudio.png
 Terminal=false
 EOF
-chmod 777 $user_home/Desktop/rstudio.desktop
+chmod 755 $user_home/Desktop/rstudio.desktop
 
 # ilastik
 if [ -f $user_home/Desktop/.scripts/ilastik ]; then
@@ -122,7 +122,7 @@ cat > $user_home/Desktop/.scripts/ilastik << 'EOF'
 module load Bioinformatics ilastik/1.4.0
 run_ilastik.sh
 EOF
-chmod 777 $user_home/Desktop/.scripts/ilastik
+chmod 755 $user_home/Desktop/.scripts/ilastik
 if [ -f $user_home/Desktop/ilastik.desktop ]; then
 	rm $user_home/Desktop/ilastik.desktop
 fi
@@ -135,7 +135,7 @@ Exec=/home/$USER/Desktop/.scripts/ilastik
 Icon=/home/$USER/Desktop/.icons/ilastik.png
 Terminal=false
 EOF
-chmod 777 $user_home/Desktop/ilastik.desktop
+chmod 755 $user_home/Desktop/ilastik.desktop
 
 # jupyter
 # note that this environment contains cellpose and jupyter lab  for segmentation and visualization
@@ -159,7 +159,7 @@ source /nfs/turbo/umms-iheemske/python-venv/cellpose-gpu/bin/activate  # comment
 
 jupyter lab
 EOF
-chmod 777 $user_home/Desktop/.scripts/jupyter
+chmod 755 $user_home/Desktop/.scripts/jupyter
 if [ -f $user_home/Desktop/jupyter.desktop ]; then
 	rm $user_home/Desktop/jupyter.desktop
 fi
@@ -172,7 +172,7 @@ Exec=/home/$USER/Desktop/.scripts/jupyter
 Icon=/home/$USER/Desktop/.icons/jupyter.png
 Terminal=true
 EOF
-chmod 777 $user_home/Desktop/jupyter.desktop
+chmod 755 $user_home/Desktop/jupyter.desktop
 
 if [ -f $user_home/Desktop/.scripts/fiji ]; then
 	rm $user_home/Desktop/.scripts/fiji
@@ -183,7 +183,7 @@ cat > $user_home/Desktop/.scripts/fiji	<< 'EOF'
 module load fiji
 fiji
 EOF
-chmod 777 $user_home/Desktop/.scripts/fiji
+chmod 755 $user_home/Desktop/.scripts/fiji
 if [ -f $user_home/Desktop/fiji.desktop ]; then
 	rm $user_home/Desktop/fiji.desktop
 fi
@@ -196,23 +196,7 @@ Exec=/home/$USER/Desktop/.scripts/fiji
 Icon=/home/$USER/Desktop/.icons/fiji.png
 Terminal=false
 EOF
-chmod 777 $user_home/Desktop/fiji.desktop
-
-#clone github repo
-# git_token="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"
-# if [ ! -d $user_home/Desktop/HeemskerkLab_sync ]; then
-# 	echo "Lab git repo does not exist. Create HeemskerkLab_sync on the desktop."
-# 	git clone "https://HeemskerkLab:${git_token}@github.com/HeemskerkLab/HeemskerkLab.git" $user_home/Desktop/HeemskerkLab_sync
-# else
-# 	echo "Lab git repo exists on the desktop. Try git pull latest changes."
-# 	cd $user_home/Desktop/HeemskerkLab_sync
-# 	git pull "https://HeemskerkLab:${git_token}@github.com/HeemskerkLab/HeemskerkLab.git" 2>/dev/null
-# 	if [ $? -ne 0 ]; then
-# 		echo "Fail to git pull latest changes. Check if git token expires or there are conflicts between remote and local."
-# 		echo "Alternatively, you can delete the current Heemskerk_sync (or save a copy) to trigger a re-clone."
-# 	fi
-# 	cd $user_home
-# fi
+chmod 755 $user_home/Desktop/fiji.desktop
 
 #add symbolic link to the scratch folder
 if [ ! -L $user_home/Desktop/${USER}_scratch_space ]; then

--- a/linux/setup/basic-packages.sh
+++ b/linux/setup/basic-packages.sh
@@ -33,6 +33,7 @@ install_basic_packages() {
             ;;
         nix)
             print_info "Nixos pkgs are handled via flake and home manager. Nothing to be done here."
+            ;;
         *)
             install_packages \
                 curl \


### PR DESCRIPTION
## Summary

Three issues found during a review of recent commits (Apr 19–22):

### 1. Security — commented-out GitHub PAT still present in `hpc/.bashrc`

PR #6 claimed to remove the commented-out GitHub personal access token but it was never actually deleted. The token `ghp_zkkwR0m...` (full value was in the file) is visible to anyone who clones the repo. Even though it is commented out, GitHub's secret scanning and third-party scrapers index it. The entire dead `#clone github repo` block has been removed.

### 2. Security — `chmod 777` not fixed in `hpc/.bashrc`

PR #6 also claimed to fix permissions from `777 → 755` for the generated desktop launcher scripts and `.desktop` files, but all 10 `chmod 777` calls remained. Fixed to `chmod 755`.

### 3. Bug — missing `;;` in `nix)` case in `linux/setup/basic-packages.sh`

The `nix)` branch added by the NixOS PRs was missing its `;;` terminator, which is a bash syntax error. On systems where `pm=nix`, the script would error out or fall through incorrectly. Added `;;`.

## Test plan

- [ ] Confirm `hpc/.bashrc` no longer contains the string `ghp_` 
- [ ] Confirm all `chmod` calls in `hpc/.bashrc` are `755`
- [ ] `bash -n linux/setup/basic-packages.sh` — no syntax errors