### PR TITLE
fix: sync ghostty/ with home-chezmoi/dot_config/ghostty/

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -5,6 +5,10 @@ window-padding-x = 5
 background = #101520
 split-divider-color = #000000
 
+# custom-shader = ./shader/bloom.glsl
+# custom-shader = ./shader/cursor_blaze_no_trail.glsl
+# somehow shaders forces macos to use higher refresh rate on ghostty
+custom-shader = ./shader/cursor_blaze_tapered.glsl
 custom-shader = ./shader/cursor_vertical_lines.glsl
 custom-shader-animation = true
 background-opacity = 0.9
@@ -15,6 +19,7 @@ cursor-style-blink = false
 shell-integration-features = no-cursor
 font-family = Iosevka
 window-decoration = true
+auto-update = download
 
 progress-style = true
 desktop-notifications = true

--- a/ghostty/shader/cursor_blaze_no_trail.glsl
+++ b/ghostty/shader/cursor_blaze_no_trail.glsl
@@ -20,9 +20,11 @@ float ease(float x) {
 }
 
 // const vec4 TRAIL_COLOR = vec4(1.0, 0.725, 0.161, 1.0);
-const vec4 TRAIL_COLOR = vec4(0.6, 0.7, 0.4, 1);
-const vec4 TRAIL_COLOR_ACCENT = vec4(0., 1., 0., 1);
-const float DURATION = 0.45; //IN SECONDS
+// const vec4 TRAIL_COLOR = vec4(0.6, 0.7, 0.4, 1);
+// const vec4 TRAIL_COLOR_ACCENT = vec4(0., 1., 0., 1);
+const vec4 TRAIL_COLOR = vec4(0.44, 0.506, 0.816, 1.0); // light purple color
+const vec4 TRAIL_COLOR_ACCENT = vec4(0.64, 0.55, 0.95, 1.0);
+const float DURATION = 0.3; //IN SECONDS
 
 void mainImage(out vec4 fragColor, in vec2 fragCoord)
 {
@@ -51,7 +53,7 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
     // Compute fade factor based on distance along the trail
 
     //cursorblaze
-    vec4 trail = mix(TRAIL_COLOR_ACCENT, fragColor, 1. - pow(smoothstep(0., sdfCurrentCursor + .002, 0.004), 2));
-    trail = mix(TRAIL_COLOR, trail, 1. - pow(smoothstep(0., sdfCurrentCursor + .002, 0.004), 2));
+    vec4 trail = mix(TRAIL_COLOR_ACCENT, fragColor, 1. - pow(smoothstep(0., sdfCurrentCursor + .002, 0.004), 1.5));
+    trail = mix(TRAIL_COLOR, trail, 1. - pow(smoothstep(0., sdfCurrentCursor + .002, 0.004), 1.5));
     fragColor = mix(trail, fragColor, 1. - pow(smoothstep(0., sdfCurrentCursor, easedProgress * lineLength), 1));
 }

--- a/ghostty/shader/cursor_blaze_tapered.glsl
+++ b/ghostty/shader/cursor_blaze_tapered.glsl
@@ -112,8 +112,8 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord)
 
     float mod = .007;
     //trailblaze
-    vec4 trail = mix(TRAIL_COLOR_ACCENT, fragColor, 1. - pow(smoothstep(0., sdfTrail + mod, 0.007), 3));
-    trail = mix(TRAIL_COLOR, trail, 1. - pow(smoothstep(0., sdfTrail + mod, 0.006), 3));
+    vec4 trail = mix(TRAIL_COLOR_ACCENT, fragColor, 1. - pow(smoothstep(0., sdfTrail + mod, 0.007), 6));
+    trail = mix(TRAIL_COLOR, trail, 1. - pow(smoothstep(0., sdfTrail + mod, 0.006), 6));
     trail = mix(trail, TRAIL_COLOR, step(sdfTrail + mod, 0.));
     //cursorblaze
     trail = mix(TRAIL_COLOR_ACCENT, trail, 1. - pow(smoothstep(0., sdfCurrentCursor + .002, 0.004), 3));

--- a/ghostty/shader/cursor_vertical_lines.glsl
+++ b/ghostty/shader/cursor_vertical_lines.glsl
@@ -62,7 +62,7 @@ float ease(float x) {
 
 const vec4  TRAIL_COLOR        = vec4(0.7, 0.4, 1.0, 1.0);
 const vec4  TRAIL_COLOR_ACCENT = vec4(0.7, 0.4, 1.0, 1.0);
-const float DURATION           = 0.35;   // seconds
+const float DURATION           = 0.45;   // seconds
 const float LINE_COUNT         = 100.0;   // vertical stripes per unit of normalized x
 
 // Bloom settings. Set BLOOM_STRENGTH to 0.0 to disable entirely; the outer


### PR DESCRIPTION
## Summary

Syncs the stale top-level `ghostty/` directory with the canonical chezmoi-managed version at `home-chezmoi/dot_config/ghostty/`.

## Changes

- **`ghostty/config`** — added `cursor_blaze_tapered.glsl` shader entry and `auto-update = download`
- **`cursor_blaze_no_trail.glsl`** — trail colors updated to light purple, duration `0.45s → 0.3s`
- **`cursor_blaze_tapered.glsl`** — smoothstep exponent `3 → 6` for a sharper trail falloff
- **`cursor_vertical_lines.glsl`** — duration `0.35s → 0.45s`

Both directories are now identical.

Closes #17
Closes #21