### PR TITLE
fix: remove phone number from emacs signature, fix tmux template, fix nushell symlink path

### DIFF
--- a/emacs/.emacs
+++ b/emacs/.emacs
@@ -131,6 +131,7 @@
 (load-theme 'myDarkTheme t)
 (setq-default line-spacing nil)
 (use-package doric-themes :ensure t :demand t)
+(use-package doom-themes :ensure t :demand t)
 
 ;; line number
 (global-display-line-numbers-mode 1)
@@ -539,7 +540,7 @@
 (setq
  user-mail-address "zhiyuanyu06@gmail.com"
  user-full-name "Zhiyuan Yu"
- message-signature (concat "Zhiyuan Yu\n" "zhiyuanyu06@gmail.com\n"))
+ message-signature (concat "Zhiyuan Yu\n" "734-881-3648\n" "zhiyuanyu06@gmail.com\n"))
 
 (require 'smtpmail)
 (setq

--- a/emacs/.emacs
+++ b/emacs/.emacs
@@ -539,7 +539,7 @@
 (setq
  user-mail-address "zhiyuanyu06@gmail.com"
  user-full-name "Zhiyuan Yu"
- message-signature (concat "Zhiyuan Yu\n" "734-881-3648\n" "zhiyuanyu06@gmail.com\n"))
+ message-signature (concat "Zhiyuan Yu\n" "zhiyuanyu06@gmail.com\n"))
 
 (require 'smtpmail)
 (setq

--- a/home-chezmoi/dot_config/symlink_nushell.tmpl
+++ b/home-chezmoi/dot_config/symlink_nushell.tmpl
@@ -1,3 +1,3 @@
 {{ if (and (eq .chezmoi.hostname "stanfish") .is_regular_linux) }}
-/home/stan/Library/Application Support/nushell
+{{ .chezmoi.homeDir }}/Library/Application Support/nushell
 {{ end }}

--- a/home-chezmoi/dot_tmux.conf.tmpl
+++ b/home-chezmoi/dot_tmux.conf.tmpl
@@ -26,9 +26,6 @@ setw -g mode-keys vi
 # mouse behavior
 setw -g mouse on
 
-# vim color scheme need xterm-256color
-set -g default-terminal "xterm-256color"
-set-option -ga terminal-overrides ",xterm-256color:Tc"
 bind-key : command-prompt
 bind-key r refresh-client
 bind-key L clear-history
@@ -88,6 +85,33 @@ set -g visual-activity on
 
 # session selection
 bind-key m run-shell 'tmux list-sessions | awk -F: '\''BEGIN {ORS=" "} {key = (NR <= 9 ? NR : sprintf("%c", 97 + NR - 10)); printf "%s %s \"switch-client -t %s\" ", $1, key, $1}'\'' | xargs tmux display-menu -T "active sessions"'
+
+# Larger history buffer
+set -g history-limit 50000
+
+# Faster escape time (better for vim/neovim)
+set -sg escape-time 10
+
+# Focus events for vim/neovim autoread
+set -g focus-events on
+
+# Better colors
+set -g default-terminal "tmux-256color"
+set -sa terminal-features ',xterm-256color:RGB'
+set -sa terminal-overrides ',xterm-256color:Tc'
+
+# Pane base index (windows already set to 1 above)
+setw -g pane-base-index 1
+
+# Renumber windows when one is closed
+set -g renumber-windows on
+
+# CCB script directory
+set -g @ccb_bin_dir "$HOME/.local/bin"
+
+# Better scroll speed
+bind -T copy-mode-vi WheelUpPane select-pane \; send-keys -X -N 2 scroll-up
+bind -T copy-mode-vi WheelDownPane select-pane \; send-keys -X -N 2 scroll-down
 
 # machine specific
 {{- if (and (eq .chezmoi.hostname "Stans-MacBook-Pro") .is_mac) }}


### PR DESCRIPTION
## Summary

Three issues found during a review of commits from Apr 21–24.

### 1. Privacy — phone number in `emacs/.emacs` mu4e signature (Apr 24 "emacs" commit)

`emacs/.emacs` contains a hardcoded phone number in the `message-signature` block:

```elisp
message-signature (concat "Zhiyuan Yu\n" "734-881-3648\n" "zhiyuanyu06@gmail.com\n"))
```

The number `734-881-3648` is publicly visible to anyone who clones the repo. The email was already in git commit metadata, but the phone number is a new leak introduced by the recent emacs commit. **Fix:** remove the phone number line from the signature.

### 2. Compatibility break — stale `xterm-256color` in `dot_tmux.conf.tmpl` (never fixed after PR #22)

PR #22 removed the dead `xterm-256color` block from `tmux/linux/.tmux.conf`, but the chezmoi template `home-chezmoi/dot_tmux.conf.tmpl` was never updated. It still contains:

```tmux
# vim color scheme need xterm-256color
set -g default-terminal "xterm-256color"
set-option -ga terminal-overrides ",xterm-256color:Tc"
```

Since `tmux-256color` is never set in the template, the macOS deployment via chezmoi is running with `xterm-256color` — which breaks true-color in neovim and other apps. The improvements added to `tmux/linux/.tmux.conf` (history-limit, escape-time, focus-events, pane-base-index, renumber-windows, scroll speed) were also never ported to the template.

**Fix:** remove the three stale lines; add `set -g default-terminal "tmux-256color"` and the full set of improvements from `tmux/linux/.tmux.conf`.

### 3. Portability bug — `symlink_nushell.tmpl` hardcodes `/home/stan/` (Apr 23 "nushell on arch" commit)

The newly added chezmoi symlink template hardcodes the username:

```
/home/stan/Library/Application Support/nushell
```

This symlink target is wrong on any account that isn't `stan`. **Fix:** use `{{ .chezmoi.homeDir }}` so chezmoi expands it to the correct home directory.

## Test plan
- [ ] `emacs/.emacs`: grep for `734-881` — should not appear
- [ ] `dot_tmux.conf.tmpl`: `tmux source ~/.tmux.conf` on macOS — no errors; `tmux info | grep Tc` shows RGB/Tc
- [ ] `symlink_nushell.tmpl`: on the `stanfish` Arch machine, `~/.config/nushell` symlink points to the correct path under `$HOME`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AV86nhaS94qrnvfVsvzsV3)_