### PR TITLE
fix: decouple i3 wallpaper path from repo clone location

### DIFF
--- a/gentoo/configs-TF-X220/home-stan/dot-config/i3/config
+++ b/gentoo/configs-TF-X220/home-stan/dot-config/i3/config
@@ -34,8 +34,9 @@ exec --no-startup-id xss-lock --transfer-sleep-lock -- i3lock --nofork
 # and nm-applet is a desktop environment-independent system tray GUI for it.
 exec --no-startup-id nm-applet
 
-# Wallpaper
-exec --no-startup-id feh --bg-scale ~/Git/my-configs/img/raccoon.jpg
+# Wallpaper — symlink target; deploy with:
+#   ln -sf ~/Git/my-configs/img/raccoon.jpg ~/.config/i3/wallpaper.jpg
+exec --no-startup-id feh --bg-scale ~/.config/i3/wallpaper.jpg
 
 # Use pactl to adjust volume in PulseAudio.
 set $refresh_i3status killall -SIGUSR1 i3status
@@ -163,10 +164,10 @@ bindsym $mod+Shift+e exec "i3-nagbar -t warning -m 'You pressed the exit shortcu
 mode "resize" {
         # These bindings trigger as soon as you enter the resize mode
 
-        # Pressing left will shrink the window’s width.
-        # Pressing right will grow the window’s width.
-        # Pressing up will shrink the window’s height.
-        # Pressing down will grow the window’s height.
+        # Pressing left will shrink the window's width.
+        # Pressing right will grow the window's width.
+        # Pressing up will shrink the window's height.
+        # Pressing down will grow the window's height.
         bindsym j resize shrink width 10 px or 10 ppt
         bindsym k resize grow height 10 px or 10 ppt
         bindsym l resize shrink height 10 px or 10 ppt


### PR DESCRIPTION
## Summary

- **`gentoo/configs-TF-X220/home-stan/dot-config/i3/config`**: replace the hardcoded repo path in the `feh` wallpaper exec line with a stable, location-independent path.

## Problem

```
exec --no-startup-id feh --bg-scale ~/Git/my-configs/img/raccoon.jpg
```

This assumes the repo is always at `~/Git/my-configs/`. On any machine where it is cloned to a different path, feh silently fails and the desktop has no wallpaper.

## Fix

```
exec --no-startup-id feh --bg-scale ~/.config/i3/wallpaper.jpg
```

`~/.config/i3/wallpaper.jpg` is a stable, repo-independent path. Wire it up once at deploy time with:

```bash
ln -sf ~/Git/my-configs/img/raccoon.jpg ~/.config/i3/wallpaper.jpg
```

## Test plan
- [ ] `~/.config/i3/wallpaper.jpg` symlink created as above
- [ ] `i3-msg restart` — wallpaper loads correctly via feh

Closes #46

---
_Generated by [Claude Code](https://claude.ai/code/session_01AQ3g5wbvWXpqBftmJdHYAT)_