### PR TITLE
fix: add default-terminal tmux-256color to Gentoo .tmux.conf

### DIFF
--- a/gentoo/configs-TF-X220/home-stan/.tmux.conf
+++ b/gentoo/configs-TF-X220/home-stan/.tmux.conf
@@ -1,2 +1,4 @@
+set -g default-terminal "tmux-256color"
+set -sa terminal-features ',xterm-256color:RGB'
 set -s set-clipboard on
 bind-key R source-file ~/.tmux.conf \; display-message "tmux.conf reloaded."


### PR DESCRIPTION
## Problem

`gentoo/configs-TF-X220/home-stan/.tmux.conf` was added (May 6) with only two lines — no `default-terminal` set. Without it tmux falls back to `screen`, which has no true-color support and breaks RGB highlighting in neovim and other apps. This is the same class of bug that PRs #16, #22, and #34 fixed for the other tmux configs in this repo.

## Fix

Add `set -g default-terminal "tmux-256color"` and `set -sa terminal-features ',xterm-256color:RGB'`, matching the established pattern. The `xterm-256color` RGB override is correct because `alacritty/alacritty.toml` sets `TERM = "xterm-256color"` in `[env]`, so tmux needs to know that outer terminal supports RGB.

## Before
```tmux
set -s set-clipboard on
bind-key R source-file ~/.tmux.conf \; display-message "tmux.conf reloaded."
```

## After
```tmux
set -g default-terminal "tmux-256color"
set -sa terminal-features ',xterm-256color:RGB'
set -s set-clipboard on
bind-key R source-file ~/.tmux.conf \; display-message "tmux.conf reloaded."
```

## Test plan
- [ ] `tmux source ~/.tmux.conf` on the TF-X220 — no errors
- [ ] `tmux info | grep Tc` — RGB/Tc reported
- [ ] True-color test in neovim works

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyoYxGpSH3HaeSbbfi1KfY)_