### PR TITLE
fix: remove HPC usernames and SetEnv TERM from ssh configs (regression from PR #39)

### DIFF
--- a/hpc/ssh/config
+++ b/hpc/ssh/config
@@ -1,6 +1,6 @@
 Host greatlakes
 	HostName greatlakes.arc-ts.umich.edu
-	User zyyu
+	# User <username>
 	ControlMaster auto
 	ControlPath ~/.ssh/controlmasters/%r@%h:%p
 	ControlPersist yes

--- a/ssh/config
+++ b/ssh/config
@@ -3,42 +3,41 @@ Host github.com
     ControlPersist 120
 Host greatlakes
     HostName greatlakes.arc-ts.umich.edu
-    User zyyu
+    # User <username>
     ControlPath ~/.ssh/controlmasters/%r@%h:%p
     ControlPersist yes
 Host greatlakes1
     HostName gl-login1.arc-ts.umich.edu
-    User zyyu
+    # User <username>
     ControlPath ~/.ssh/controlmasters/%r@%h:%p
     ControlPersist yes
 Host greatlakes2
     HostName gl-login2.arc-ts.umich.edu
-    User zyyu
+    # User <username>
     ControlPath ~/.ssh/controlmasters/%r@%h:%p
     ControlPersist yes
 Host greatlakes3
     HostName gl-login3.arc-ts.umich.edu
-    User zyyu
+    # User <username>
     ControlPath ~/.ssh/controlmasters/%r@%h:%p
     ControlPersist yes
 Host greatlakes4
     HostName gl-login4.arc-ts.umich.edu
-    User zyyu
+    # User <username>
     ControlPath ~/.ssh/controlmasters/%r@%h:%p
     ControlPersist yes
 Host greatlakes5
     HostName gl-login5.arc-ts.umich.edu
-    User zyyu
+    # User <username>
     ControlPath ~/.ssh/controlmasters/%r@%h:%p
     ControlPersist yes
 Host bridges2
     HostName br013.bridges2.psc.edu
-    User zyu14
+    # User <username>
     ControlPath ~/.ssh/controlmasters/%r@%h:%p
     ControlPersist yes
 Host *
     ControlMaster auto
-    SetEnv TERM=xterm-256color
     ControlPath ~/.ssh/controlmasters/%r@%h:%p
     ControlPersist 1800
     Compression yes


### PR DESCRIPTION
Closes #49

## Problem

PR #39 claimed to fix `ssh/config` and `hpc/ssh/config` but the changes were never applied. Both files still had live HPC usernames (`zyyu`, `zyu14`) and `ssh/config`'s `Host *` still had `SetEnv TERM=xterm-256color`.

## Changes

**`ssh/config`**
- `User zyyu` → `# User <username>` for `greatlakes`, `greatlakes1`–`greatlakes5`
- `User zyu14` → `# User <username>` for `bridges2`
- Removed `SetEnv TERM=xterm-256color` from `Host *`

**`hpc/ssh/config`**
- `User zyyu` → `# User <username>` for `greatlakes`

## Test plan
- [ ] `grep -r 'zyyu\|zyu14' ssh/ hpc/ssh/` — no matches
- [ ] `grep 'SetEnv' ssh/config` — no matches
- [ ] SSH to greatlakes works after adding `User` back locally

---
_Generated by [Claude Code](https://claude.ai/code/session_0177hK1PcXPCCaGbRduJ3dNA)_