### PR TITLE
fix: remove SetEnv TERM=xterm-256color from ssh/config Host *

### DIFF
--- a/ssh/config
+++ b/ssh/config
@@ -38,7 +38,6 @@ Host bridges2
     ControlPersist yes
 Host *
     ControlMaster auto
-    SetEnv TERM=xterm-256color
     ControlPath ~/.ssh/controlmasters/%r@%h:%p
     ControlPersist 1800
     Compression yes


### PR DESCRIPTION
Closes #54\n\n## Problem\n\nCommit `af605023` ("fix ssh term") re-added `SetEnv TERM=xterm-256color` to `Host *` on the same branch as PR #50, undoing the intentional removal in `57482bc`. PR #53 (Copilot draft) attempted to remove it again but was closed without merging.\n\n## Why it must go\n\n- **Conflicts with tmux-256color** — inside tmux `TERM` is `tmux-256color` (PRs #16 #22 #34 #48). Forcing `xterm-256color` over SSH overwrites this on the remote side, breaking true-color in neovim.\n- **Silently no-ops on HPC** — greatlakes/bridges2 do not set `AcceptEnv TERM` in `sshd_config`, so the directive is already ignored there.\n- **Was intentionally deleted** — `57482bc` in PR #50 removed this exact line.\n\n## Change\n\nOne-line deletion from `Host *` in `ssh/config`:\n\n```diff\n Host *\n     ControlMaster auto\n-    SetEnv TERM=xterm-256color\n     ControlPath ~/.ssh/controlmasters/%r@%h:%p\n     ControlPersist 1800\n     Compression yes\n     TCPKeepAlive yes\n     ServerAliveInterval 20\n     ServerAliveCountMax 10\n```\n\n## Test plan\n- [ ] `grep SetEnv ssh/config` — no matches\n- [ ] SSH to any host — TERM inherits from the local terminal as expected

---
_Generated by [Claude Code](https://claude.ai/code/session_01EeRh3pEW4PFja4j39Ruqrj)_