### PR TITLE
fix: redact personal email from git/.gitconfig

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -1,6 +1,6 @@
 [user]
 	name = Stan
-	email = zyyu@umich.edu
+	# email = <your-email>
 [merge]
 	tool = nvimdiff
 [diff]


### PR DESCRIPTION
Closes #57

## Problem

`git/.gitconfig` line 3 had `email = zyyu@umich.edu` — the same personal institutional identifier that PRs #39 and #50 removed from `ssh/config` and `hpc/ssh/config`. It was missed in those rounds.

## Change

```diff
-	email = zyyu@umich.edu
+	# email = <your-email>
```

One line, same placeholder pattern used elsewhere in the repo.

## Notes

- `home-chezmoi/.chezmoi.toml.tmpl` already uses `promptStringOnce` for email — no change needed there.
- `name = Stan` is kept as-is (a first name poses no access risk).

## Test plan
- [ ] `grep -r 'zyyu@\|zyu14@' git/` — no matches

---
_Generated by [Claude Code](https://claude.ai/code/session_01RzoRBgzZZypgTD91rsdRAk)_