### PR TITLE
fix: redact personal email from git/.gitconfig

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -1,6 +1,6 @@
 [user]
 	name = Stan
-	email = zyyu@umich.edu
+	# email =
 [merge]
 	tool = nvimdiff
 [diff]


### PR DESCRIPTION
Closes #57

## Problem

`git/.gitconfig` line 3 has `email = zyyu@umich.edu` — a personal institutional email visible to anyone who clones the repo. PR #58 attempted this fix but was closed without merging.

## Change

```diff
-	email = zyyu@umich.edu
+	# email =
```

Same placeholder pattern used for `User` in `ssh/config` and `hpc/ssh/config`.

## Test plan
- [ ] `grep -r 'zyyu@\|zhiyuan' git/` — no matches

---
_Generated by [Claude Code](https://claude.ai/code/session_018zYmyLUmJYT1mvAZms88L4)_