### PR TITLE
fix: correct hypridle dispatch syntax and swaybg path in hyprland configs

### DIFF
--- a/hyprland/hypridle.conf
+++ b/hyprland/hypridle.conf
@@ -1,11 +1,11 @@
 general {
     lock_cmd = notify-send "Locking soon..."   # optional
     before_sleep_cmd = loginctl lock-session
-    after_sleep_cmd = hyprctl dispatch 'hl.dsp.dpms({ action = "{enable}" })'
+    after_sleep_cmd = hyprctl dispatch dpms on
 }
 
 listener {
     timeout = 600
-    on-timeout = hyprctl dispatch 'hl.dsp.dpms({ action = "{disable}" })'
-    on-resume = hyprctl dispatch 'hl.dsp.dpms({ action = "{enable}" })'
+    on-timeout = hyprctl dispatch dpms off
+    on-resume = hyprctl dispatch dpms on
 }

--- a/hyprland/hyprland.lua
+++ b/hyprland/hyprland.lua
@@ -51,7 +51,7 @@ local menu        = "rofi -show drun -config ~/.config/rofi/config.rasi"
 -- end)
 
 hl.on("hyprland.start", function ()
-    hl.exec_cmd("swaybg -i swaybg -i Git/my-configs/img/bw_geometry.png -m fill & waybar")
+    hl.exec_cmd("swaybg -i ~/.config/hypr/wallpaper.jpg -m fill & waybar")
     hl.exec_cmd("hypridle")
 end
 )


### PR DESCRIPTION
Two bugs introduced in the May 15 hyprland Lua migration.

## 1. `hyprland/hypridle.conf` — wrong dispatch syntax (compatibility break)

`hyprctl dispatch` takes keyword-based commands (`dpms off`, `dpms on`), not Lua API expressions. The `hl.dsp.dpms({...})` syntax only works inside `hyprland.lua` itself — passing it as a shell argument to `hyprctl dispatch` would silently fail, leaving DPMS non-functional.

```diff
-    after_sleep_cmd = hyprctl dispatch 'hl.dsp.dpms({ action = "{enable}" })'
+    after_sleep_cmd = hyprctl dispatch dpms on
 ...
-    on-timeout = hyprctl dispatch 'hl.dsp.dpms({ action = "{disable}" })'
-    on-resume  = hyprctl dispatch 'hl.dsp.dpms({ action = "{enable}" })'
+    on-timeout = hyprctl dispatch dpms off
+    on-resume  = hyprctl dispatch dpms on
```

## 2. `hyprland/hyprland.lua` — double `-i` typo + hardcoded repo path

The swaybg autostart line had `-i swaybg -i Git/my-configs/img/bw_geometry.png` — "swaybg" was being passed as the image path (copy-paste artifact from the command name), and the path assumed the repo is cloned at `~/Git/my-configs/`.

```diff
-    hl.exec_cmd("swaybg -i swaybg -i Git/my-configs/img/bw_geometry.png -m fill & waybar")
+    hl.exec_cmd("swaybg -i ~/.config/hypr/wallpaper.jpg -m fill & waybar")
```

`~/.config/hypr/wallpaper.jpg` is a stable, location-independent path. Wire it up once at deploy time:
```bash
ln -sf ~/Git/my-configs/img/bw_geometry.png ~/.config/hypr/wallpaper.jpg
```

(Same pattern used in PR #47 for the i3 wallpaper path.)

## Test plan
- [ ] `hyprctl dispatch dpms off` — display turns off
- [ ] `hyprctl dispatch dpms on` — display turns on
- [ ] `hypridle` running — display turns off after 10 min idle
- [ ] Hyprland starts with wallpaper after symlinking `~/.config/hypr/wallpaper.jpg`

https://claude.ai/code/session_01ME1dkChBv2iqPdD1ZGPoVz

---
_Generated by [Claude Code](https://claude.ai/code/session_01ME1dkChBv2iqPdD1ZGPoVz)_