### PR TITLE
fix: hyprland.lua Super+M exit fallback uses invalid hyprctl dispatch syntax

### DIFF
--- a/hyprland/hyprland.lua
+++ b/hyprland/hyprland.lua
@@ -266,7 +266,7 @@ local mainMod_SHIFT = "SUPER + SHIFT"
 hl.bind(mainMod .. " + Q", hl.dsp.exec_cmd(terminal))
 local closeWindowBind = hl.bind(mainMod .. " + C", hl.dsp.window.close())
 -- closeWindowBind:set_enabled(false)
-hl.bind(mainMod .. " + M", hl.dsp.exec_cmd("command -v hyprshutdown >/dev/null 2>&1 && hyprshutdown || hyprctl dispatch 'hl.dsp.exit()'"))
+hl.bind(mainMod .. " + M", hl.dsp.exec_cmd("command -v hyprshutdown >/dev/null 2>&1 && hyprshutdown || hyprctl dispatch exit"))
 hl.bind(mainMod .. " + E", hl.dsp.exec_cmd(fileManager))
 hl.bind(mainMod .. " + V", hl.dsp.window.float({ action = "toggle" }))
 hl.bind(mainMod .. " + R", hl.dsp.exec_cmd(menu))


### PR DESCRIPTION
Closes #66

## Problem

The Super+M keybind in `hyprland/hyprland.lua` has a broken fallback when `hyprshutdown` is not installed:

```lua
hl.bind(mainMod .. " + M", hl.dsp.exec_cmd("... || hyprctl dispatch 'hl.dsp.exit()'"))
```

`hl.dsp.exit()` is a Hyprland Lua API call — it only works inside `hyprland.lua`'s runtime. Passing it as a string argument to `hyprctl dispatch` silently does nothing. Same class of bug as #63 (DPMS dispatch syntax).

## Fix

```diff
-hl.bind(mainMod .. " + M", hl.dsp.exec_cmd("command -v hyprshutdown >/dev/null 2>&1 && hyprshutdown || hyprctl dispatch 'hl.dsp.exit()'"))
+hl.bind(mainMod .. " + M", hl.dsp.exec_cmd("command -v hyprshutdown >/dev/null 2>&1 && hyprshutdown || hyprctl dispatch exit"))
```

`exit` is the correct `hyprctl dispatch` keyword for exiting Hyprland (same as running `hyprctl dispatch exit` from a terminal).

## Test plan
- [ ] With `hyprshutdown` not installed: Super+M exits Hyprland via `hyprctl dispatch exit`
- [ ] With `hyprshutdown` installed: Super+M runs `hyprshutdown` as before

https://claude.ai/code/session_012DfvhcoCZW5kaqUu9R5XXm

---
_Generated by [Claude Code](https://claude.ai/code/session_012DfvhcoCZW5kaqUu9R5XXm)_