### PR TITLE
fix: auto-raise sudo permission in clean-disk.sh

### DIFF
--- a/linux/system/clean-disk.sh
+++ b/linux/system/clean-disk.sh
@@ -76,6 +76,8 @@ clean_language_package_managers() {
 clean_disk() {
     print_info "Cleaning disk space..."
 
+    check_sudo_access || return 1
+
     # Clean user cache
     print_info "Removing user cache..."
     if [[ "$DRY_RUN" != "true" ]]; then


### PR DESCRIPTION
Call check_sudo_access() at the start of clean_disk() so sudo credentials are obtained upfront before any sudo commands run. Previously the nix (and other) cleanup paths could fail mid-run when sudo authentication wasn't cached.

Fixes #62

Generated with [Claude Code](https://claude.ai/code)