### PR TITLE
fix: redact email, use ~ in signingkey, remove hardcoded safe.directory from git/.gitconfig

### DIFF
--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -1,23 +1,20 @@
-# add dirs not owned by current user
-[safe]
-    directory = /home/stan/nixos
 [user]
-    name = Stan
-    email = zyyu@umich.edu
-    signingkey = /home/stan/.ssh/id_ed25519.pub
+	name = Stan
+	# email =
+	signingkey = ~/.ssh/id_ed25519.pub
 [gpg]
-    format = ssh
+	format = ssh
 [commit]
-    gpgsign = true
+	gpgsign = true
 [merge]
-    tool = nvimdiff
+	tool = nvimdiff
 [diff]
-    tool = nvimdiff
+	tool = nvimdiff
 [difftool]
-    prompt = true
-    trustExitCode = true
+	prompt = true
+	trustExitCode = true
 # workflow: gh pr checkout ... -> git difftool ... or git difftool -d ...
 [difftool "nvimdiff"]
-    cmd = nvim -c \"packadd nvim.difftool\" -d \"$LOCAL\" \"$REMOTE\"
+	cmd = nvim -c "packadd nvim.difftool" -d "$LOCAL" "$REMOTE"
 [credential]
-    helper = cache
+	helper = cache


### PR DESCRIPTION
Closes #71\nCloses #61\n\nThree issues in `git/.gitconfig` introduced/persisting through the May 15 \"update\" commit:\n\n### 1. Personal email redacted\n\n```diff\n-\temail = zyyu@umich.edu\n+\t# email =\n```\n\nSame placeholder pattern used for `User` in `ssh/config` and `hpc/ssh/config`. Tracked since issue #57; previous PRs #58 and #59 were closed without merging; draft PR #70 (Copilot) also targets this.\n\n### 2. `user.signingkey` — replace `/home/stan/` with `~`\n\n```diff\n-\tsigningkey = /home/stan/.ssh/id_ed25519.pub\n+\tsigningkey = ~/.ssh/id_ed25519.pub\n```\n\nGit expands `~` in `user.signingKey` for the SSH signing format. The hardcoded path breaks on any non-stan machine.\n\n### 3. `[safe] directory` — remove hardcoded machine-specific entry\n\n```diff\n-# add dirs not owned by current user\n-[safe]\n-    directory = /home/stan/nixos\n```\n\n`safe.directory` does not support `~` expansion, so this entry must be set locally per machine. Committing it exposes the system username and a private path. Add it locally with:\n```bash\ngit config --global safe.directory /path/to/your/nixos\n```\n\n## Test plan\n- [ ] `grep 'home/stan\\|zyyu@' git/.gitconfig` — no matches\n- [ ] Git commit signing works after deploying updated config\n- [ ] `git config --global user.signingKey` on a non-stan machine resolves to `~/.ssh/id_ed25519.pub`\n

---
_Generated by [Claude Code](https://claude.ai/code/session_01LUFfjierkSf6xGUpbkr6iF)_