### PR TITLE
fix: claude popup (bind-key y) opens in wrong directory

### DIFF
--- a/tmux/linux/.tmux.conf
+++ b/tmux/linux/.tmux.conf
@@ -124,5 +124,5 @@ bind -T copy-mode-vi WheelDownPane select-pane \; send-keys -X -N 2 scroll-down
 bind-key y run-shell '\
     SESSION="claude-$(echo #{pane_current_path} | md5sum | cut -c1-8)"; \
     tmux has-session -t "$SESSION" 2>/dev/null || \
-    tmux new-session -d -s "$SESSION" -c "${pane_current_path}" "claude"; \
+    tmux new-session -d -s "$SESSION" -c "#{pane_current_path}" "claude"; \
     tmux display-popup -w80% -h80% -E "tmux attach-session -t $SESSION"'


### PR DESCRIPTION
## Problem

`bind-key y` in `tmux/linux/.tmux.conf` uses `${pane_current_path}` (a shell variable) for the `-c` flag of `tmux new-session`, but this variable is never set in the shell environment — so every new claude session is created in the tmux server's default working directory instead of the pane's current path.

The session name is correctly hashed from `#{pane_current_path}` (tmux format, expanded before the shell runs), but the working directory passed to `-c` silently expands to empty string.

## Fix

```diff
-    tmux new-session -d -s "$SESSION" -c "${pane_current_path}" "claude"; \
+    tmux new-session -d -s "$SESSION" -c "#{pane_current_path}" "claude"; \
```

`#{pane_current_path}` is a tmux format string — tmux expands it to the real path before passing the command to the shell, so the new claude session gets started in the correct directory.

## Test plan
- [ ] Press `y` in a pane whose cwd is e.g. `~/myproject`
- [ ] claude session should open with `~/myproject` as its working directory
- [ ] Second press of `y` reattaches to the same session (no duplicate created)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sz3mJTttP79RYUx95oVr4M)_