### PR TITLE
sync tmux configs: add lazygit popup, remove backslash bind, fix TPM position

### DIFF
--- a/home-chezmoi/dot_tmux.conf.tmpl
+++ b/home-chezmoi/dot_tmux.conf.tmpl
@@ -47,7 +47,6 @@ bind -n C-h run "(tmux display-message -p '#{pane_current_command}' | grep -iqE 
 bind -n C-j run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys C-j) || tmux select-pane -D"
 bind -n C-k run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys C-k) || tmux select-pane -U"
 bind -n C-l run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys C-l) || tmux select-pane -R"
-bind -n 'C-\' run "(tmux display-message -p '#{pane_current_command}' | grep -iqE '(^|\/)vim$' && tmux send-keys 'C-\\') || tmux select-pane -l"
 bind C-l send-keys 'C-l'
 bind-key C-o rotate-window
 
@@ -63,6 +62,8 @@ set-window-option -g display-panes-time 1500
 bind-key a last-pane
 bind-key q display-panes
 bind-key c new-window
+# set current session's working dir (useful for later spawn of agents)
+bind-key M-c attach-session -c "#{pane_current_path}"
 bind-key t next-window
 bind-key T previous-window
 
@@ -94,6 +95,10 @@ set -sg escape-time 10
 
 # Focus events for vim/neovim autoread
 set -g focus-events on
+
+# Ensure clipboard-related env vars stay updated when attaching from GUI/remote sessions.
+# (Important on Wayland/WSL, and when tmux server was started without DISPLAY.)
+set -g update-environment "DISPLAY WAYLAND_DISPLAY XDG_RUNTIME_DIR WSL_DISTRO_NAME WSL_INTEROP SSH_AUTH_SOCK SSH_CONNECTION"
 
 # Better colors
 set -g default-terminal "tmux-256color"
@@ -128,12 +133,19 @@ bind -T resize-mode Up resize-pane -U 5 \; switch-client -T resize-mode
 bind -T resize-mode Down resize-pane -D 5 \; switch-client -T resize-mode
 {{- end }}
 
-# Run claude code in a pop-up window (todo: might be interesting to create a table to select what agent/program to run) 
+# Run claude code in a pop-up window (todo: might be interesting to create a table to select what agent/program to run)
 # It uses md5sum to hash the session name, then resume/create claude session
 bind-key y run-shell '\
     SESSION="claude-$(echo #{pane_current_path} | md5sum | cut -c1-8)"; \
     tmux has-session -t "$SESSION" 2>/dev/null || \
     tmux new-session -d -s "$SESSION" -c "#{pane_current_path}" "claude"; \
+    tmux display-popup -w80% -h80% -E "tmux attach-session -t $SESSION"'
+
+# Run lazygit in a pop-up window, resuming the same session per working directory
+bind-key g run-shell '\
+    SESSION="lazygit-$(echo #{pane_current_path} | md5sum | cut -c1-8)"; \
+    tmux has-session -t "$SESSION" 2>/dev/null || \
+    tmux new-session -d -s "$SESSION" -c "#{pane_current_path}" "lazygit"; \
     tmux display-popup -w80% -h80% -E "tmux attach-session -t $SESSION"'
 
 # Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)

--- a/tmux/linux/.tmux.conf
+++ b/tmux/linux/.tmux.conf
@@ -53,6 +53,8 @@ bind-key C-o rotate-window
 bind-key + select-layout main-horizontal
 bind-key = select-layout main-vertical
 
+bind-key C-c kill-pane
+
 set-window-option -g other-pane-height 25
 set-window-option -g other-pane-width 80
 set-window-option -g display-panes-time 1500
@@ -85,9 +87,6 @@ set -g visual-activity on
 # session selection
 bind-key m run-shell 'tmux list-sessions | awk -F: '\''BEGIN {ORS=" "} {key = (NR <= 9 ? NR : sprintf("%c", 97 + NR - 10)); printf "%s %s \"switch-client -t %s\" ", $1, key, $1}'\'' | xargs tmux display-menu -T "active sessions"'
 
-# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
-run '~/.tmux/plugins/tpm/tpm'
-
 # Larger history buffer
 set -g history-limit 50000
 
@@ -119,10 +118,20 @@ set -g @ccb_bin_dir "$HOME/.local/bin"
 bind -T copy-mode-vi WheelUpPane select-pane \; send-keys -X -N 2 scroll-up
 bind -T copy-mode-vi WheelDownPane select-pane \; send-keys -X -N 2 scroll-down
 
-# Run claude code in a pop-up window (todo: might be interesting to create a table to select what agent/program to run) 
+# Run claude code in a pop-up window (todo: might be interesting to create a table to select what agent/program to run)
 # It uses md5sum to hash the session name, then resume/create claude session
 bind-key y run-shell '\
     SESSION="claude-$(echo #{pane_current_path} | md5sum | cut -c1-8)"; \
     tmux has-session -t "$SESSION" 2>/dev/null || \
     tmux new-session -d -s "$SESSION" -c "#{pane_current_path}" "claude"; \
     tmux display-popup -w80% -h80% -E "tmux attach-session -t $SESSION"'
+
+# Run lazygit in a pop-up window, resuming the same session per working directory
+bind-key g run-shell '\
+    SESSION="lazygit-$(echo #{pane_current_path} | md5sum | cut -c1-8)"; \
+    tmux has-session -t "$SESSION" 2>/dev/null || \
+    tmux new-session -d -s "$SESSION" -c "#{pane_current_path}" "lazygit"; \
+    tmux display-popup -w80% -h80% -E "tmux attach-session -t $SESSION"'
+
+# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
+run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
Closes #74

- Add lazygit popup (bind-key g) to both configs, same session-per-dir pattern as the claude popup
- Remove the C-\ backslash pane switch from chezmoi template
- Add kill-pane (C-c) to linux conf
- Add M-c session working-dir bind to chezmoi template
- Add update-environment vars to chezmoi template (Wayland/WSL support)
- Move TPM run line to very bottom of linux conf

Generated with [Claude Code](https://claude.ai/code)