### PR TITLE
fix: redact HPC username and remove hardcoded home paths

### DIFF
--- a/hpc/monitor_job.sh
+++ b/hpc/monitor_job.sh
@@ -32,7 +32,7 @@ while true; do
   printf "%-10s %-8s %-10s %-8s %-10s %-8s\n" "JOBID" "TIME" "NODE" "MaxMem" "CPUTime" "CPU%"
   printf "%-10s %-8s %-10s %-8s %-10s %-8s\n" "----------" "--------" "----------" "--------" "----------" "--------"
   
-  for jobid in $(squeue -u zyyu -h -o "%i"); do
+  for jobid in $(squeue -u "$USER" -h -o "%i"); do
     elapsed=$(squeue -j $jobid -h -o "%M")
     node=$(squeue -j $jobid -h -o "%N")
     ncpus=$(squeue -j $jobid -h -o "%C")

--- a/linux/services/email.service
+++ b/linux/services/email.service
@@ -8,8 +8,8 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=1
-User=stanfish
-ExecStart=/home/stanfish/scripts/system/fetch-emails.sh
+# User=  # set locally: User=your-username
+ExecStart=%h/scripts/system/fetch-emails.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/sway/40-sway-background.conf
+++ b/sway/40-sway-background.conf
@@ -1,1 +1,1 @@
-output * bg /home/stanfish/Git/my-configs/img/space.jpeg fill
+output * bg ~/.config/sway/wallpaper.jpeg fill

--- a/wezterm/.wezterm.lua
+++ b/wezterm/.wezterm.lua
@@ -353,7 +353,7 @@ domains.apply_to_config(config, {
 config.ssh_domains = { {
 	name = "greatlakes",
 	remote_address = "greatlakes.arc-ts.umich.edu",
-	username = "zyyu",
+	username = "username",
 } }
 
 -- wezterm will automatically connect to unix mux server
@@ -367,7 +367,7 @@ config.default_gui_startup_args = { "connect", "unix" }
 config.launch_menu = {
 	{
 		label = "greatlakes",
-		args = { "ssh", "zyyu@greatlakes.arc-ts.umich.edu" },
+		args = { "ssh", "username@greatlakes.arc-ts.umich.edu" },
 	},
 	{
 		label = "msvc",


### PR DESCRIPTION
Closes #77
Closes #78

## Changes

### 1. `hpc/monitor_job.sh` — use `$USER` instead of `zyyu` (info leak)

```diff
-  for jobid in $(squeue -u zyyu -h -o "%i"); do
+  for jobid in $(squeue -u "$USER" -h -o "%i"); do
```

`zyyu` was a hardcoded HPC username missed when PR #39/PR #50 cleaned `ssh/config` and `hpc/ssh/config`. Using `$USER` makes the script work for any account.

### 2. `wezterm/.wezterm.lua` — redact `zyyu` username (info leak)

```diff
-	username = "zyyu",
+	username = "username",
...
-		args = { "ssh", "zyyu@greatlakes.arc-ts.umich.edu" },
+		args = { "ssh", "username@greatlakes.arc-ts.umich.edu" },
```

Same redaction pattern as `ssh/config` (PR #50).

### 3. `sway/40-sway-background.conf` — stable wallpaper path (compatibility)

```diff
-output * bg /home/stanfish/Git/my-configs/img/space.jpeg fill
+output * bg ~/.config/sway/wallpaper.jpeg fill
```

Same pattern as PR #47 for i3. Wire up at deploy time:
```bash
ln -sf ~/Git/my-configs/img/space.jpeg ~/.config/sway/wallpaper.jpeg
```

### 4. `linux/services/email.service` — use `%h` specifier (compatibility)

```diff
-User=stanfish
-ExecStart=/home/stanfish/scripts/system/fetch-emails.sh
+# User=  # set locally: User=your-username
+ExecStart=%h/scripts/system/fetch-emails.sh
```

`%h` is the systemd home-directory specifier for the configured `User=`.

## Test plan
- [ ] `grep -r 'zyyu\|zyu14' hpc/monitor_job.sh wezterm/` — no matches
- [ ] `grep -r 'home/stanfish' sway/ linux/services/` — no matches
- [ ] `monitor_job.sh` on HPC lists current user's jobs
- [ ] Sway starts with wallpaper after symlinking `~/.config/sway/wallpaper.jpeg`

---
https://claude.ai/code/session_01WgPdS4Zw5VcKhxYsuvCWXq

---
_Generated by [Claude Code](https://claude.ai/code/session_01WgPdS4Zw5VcKhxYsuvCWXq)_