### PR TITLE
fix: redact remaining personal identifiers in hpc, wezterm, sway, and email.service

### DIFF
--- a/hpc/monitor_job.sh
+++ b/hpc/monitor_job.sh
@@ -32,7 +32,7 @@ while true; do
   printf "%-10s %-8s %-10s %-8s %-10s %-8s\n" "JOBID" "TIME" "NODE" "MaxMem" "CPUTime" "CPU%"
   printf "%-10s %-8s %-10s %-8s %-10s %-8s\n" "----------" "--------" "----------" "--------" "----------" "--------"
   
-  for jobid in $(squeue -u zyyu -h -o "%i"); do
+  for jobid in $(squeue -u "$USER" -h -o "%i"); do
     elapsed=$(squeue -j $jobid -h -o "%M")
     node=$(squeue -j $jobid -h -o "%N")
     ncpus=$(squeue -j $jobid -h -o "%C")

--- a/linux/services/email.service
+++ b/linux/services/email.service
@@ -8,8 +8,8 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=1
-User=stanfish
-ExecStart=/home/stanfish/scripts/system/fetch-emails.sh
+# User=  # set locally: User=your-username
+ExecStart=%h/scripts/system/fetch-emails.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/sway/40-sway-background.conf
+++ b/sway/40-sway-background.conf
@@ -1,1 +1,1 @@
-output * bg /home/stanfish/Git/my-configs/img/space.jpeg fill
+output * bg ~/.config/sway/wallpaper.jpeg fill

--- a/wezterm/.wezterm.lua
+++ b/wezterm/.wezterm.lua
@@ -9,7 +9,7 @@ workspace_switcher.apply_to_config(config)
 
 config.window_decorations = "RESIZE"
 config.background = {
-	{ source = { File = "C:/Users/zhiyu/Desktop/Git/my-configs/img/dark-green-forest.jpg" }, opacity = 0.4 },
+	{ source = { File = wezterm.home_dir .. "/.config/wezterm/background.jpg" }, opacity = 0.4 },
 }
 -- config.window_decorations = "INTEGRATED_BUTTONS | RESIZE"
 -- config.integrated_title_button_alignment = "Left"
@@ -353,7 +353,7 @@ domains.apply_to_config(config, {
 config.ssh_domains = { {
 	name = "greatlakes",
 	remote_address = "greatlakes.arc-ts.umich.edu",
-	username = "zyyu",
+	username = "username",
 } }
 
 -- wezterm will automatically connect to unix mux server
@@ -367,7 +367,7 @@ config.default_gui_startup_args = { "connect", "unix" }
 config.launch_menu = {
 	{
 		label = "greatlakes",
-		args = { "ssh", "zyyu@greatlakes.arc-ts.umich.edu" },
+		args = { "ssh", "username@greatlakes.arc-ts.umich.edu" },
 	},
 	{
 		label = "msvc",


### PR DESCRIPTION
Closes #77
Closes #78
Closes #80

PR #79 was closed without merging. Issues #77 and #78 remain open. This PR re-applies those fixes and also addresses the newly-found #80 (wezterm background path).

## Changes

### 1. `hpc/monitor_job.sh` — use `$USER` instead of `zyyu` (issue #77)

```diff
-  for jobid in $(squeue -u zyyu -h -o "%i"); do
+  for jobid in $(squeue -u "$USER" -h -o "%i"); do
```

### 2. `wezterm/.wezterm.lua` — three redactions

**issue #77** — HPC username in ssh_domains and launch_menu:
```diff
-    username = "zyyu",
+    username = "username",
...
-        args = { "ssh", "zyyu@greatlakes.arc-ts.umich.edu" },
+        args = { "ssh", "username@greatlakes.arc-ts.umich.edu" },
```

**issue #80** — personal Windows username `zhiyu` in background image path:
```diff
-    { source = { File = "C:/Users/zhiyu/Desktop/Git/my-configs/img/dark-green-forest.jpg" }, opacity = 0.4 },
+    { source = { File = wezterm.home_dir .. "/.config/wezterm/background.jpg" }, opacity = 0.4 },
```

Wire up at deploy time:
```powershell
New-Item -ItemType SymbolicLink -Path "$env:USERPROFILE\.config\wezterm\background.jpg" -Target "$env:USERPROFILE\Desktop\Git\my-configs\img\dark-green-forest.jpg"
```

### 3. `sway/40-sway-background.conf` — stable wallpaper path (issue #78)

```diff
-output * bg /home/stanfish/Git/my-configs/img/space.jpeg fill
+output * bg ~/.config/sway/wallpaper.jpeg fill
```

Wire up at deploy time:
```bash
ln -sf ~/Git/my-configs/img/space.jpeg ~/.config/sway/wallpaper.jpeg
```

### 4. `linux/services/email.service` — use `%h` specifier (issue #78)

```diff
-User=stanfish
-ExecStart=/home/stanfish/scripts/system/fetch-emails.sh
+# User=  # set locally: User=your-username
+ExecStart=%h/scripts/system/fetch-emails.sh
```

## Test plan
- [ ] `grep -r 'zyyu\|zyu14' hpc/monitor_job.sh wezterm/` — no matches
- [ ] `grep -r 'zhiyu\|Users/' wezterm/` — no matches
- [ ] `grep -r 'home/stanfish' sway/ linux/services/` — no matches
- [ ] `monitor_job.sh` on HPC lists current user's jobs
- [ ] Sway starts with wallpaper after symlinking `~/.config/sway/wallpaper.jpeg`
- [ ] WezTerm starts with background after symlinking `~/.config/wezterm/background.jpg`

---
_Generated by [Claude Code](https://claude.ai/code/session_014CXPwzzpvXqvuZk6UeMf6k)_