### PR TITLE
fix: redact personal identifiers in wezterm, sway, email.service

### DIFF
--- a/linux/services/email.service
+++ b/linux/services/email.service
@@ -8,8 +8,8 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=1
-User=stanfish
-ExecStart=/home/stanfish/scripts/system/fetch-emails.sh
+# User=  # set locally: User=your-username
+ExecStart=%h/scripts/system/fetch-emails.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/sway/40-sway-background.conf
+++ b/sway/40-sway-background.conf
@@ -1,1 +1,1 @@
-output * bg /home/stanfish/Git/my-configs/img/space.jpeg fill
+output * bg ~/.config/sway/wallpaper.jpeg fill

--- a/wezterm/.wezterm.lua
+++ b/wezterm/.wezterm.lua
@@ -9,7 +9,7 @@ workspace_switcher.apply_to_config(config)
 
 config.window_decorations = "RESIZE"
 config.background = {
-	{ source = { File = "C:/Users/zhiyu/Desktop/Git/my-configs/img/dark-green-forest.jpg" }, opacity = 0.4 },
+	{ source = { File = wezterm.home_dir .. "/.config/wezterm/background.jpg" }, opacity = 0.4 },
 }
 -- config.window_decorations = "INTEGRATED_BUTTONS | RESIZE"
 -- config.integrated_title_button_alignment = "Left"
@@ -127,7 +127,7 @@ function kill_workspace(workspace)
 				"kill-pane",
 				"--pane-id=" .. p.pane_id,
 			})
-		end
+			end
 	end
 end
 


### PR DESCRIPTION
Closes #82

PR #81 addressed these three leaks but was closed without merging. This re-applies the same fixes.

## Changes

### 1. `wezterm/.wezterm.lua` — Windows username `zhiyu` in background path

```diff
-{ source = { File = "C:/Users/zhiyu/Desktop/Git/my-configs/img/dark-green-forest.jpg" }, opacity = 0.4 },
+{ source = { File = wezterm.home_dir .. "/.config/wezterm/background.jpg" }, opacity = 0.4 },
```

Wire up at deploy time:
```powershell
New-Item -ItemType SymbolicLink -Path "$env:USERPROFILE\.config\wezterm\background.jpg" -Target "$env:USERPROFILE\Desktop\Git\my-configs\img\dark-green-forest.jpg"
```

### 2. `sway/40-sway-background.conf` — hardcoded `/home/stanfish/` path

```diff
-output * bg /home/stanfish/Git/my-configs/img/space.jpeg fill
+output * bg ~/.config/sway/wallpaper.jpeg fill
```

Wire up at deploy time:
```bash
ln -sf ~/Git/my-configs/img/space.jpeg ~/.config/sway/wallpaper.jpeg
```

### 3. `linux/services/email.service` — `User=stanfish` and `/home/stanfish/` path

```diff
-User=stanfish
-ExecStart=/home/stanfish/scripts/system/fetch-emails.sh
+# User=  # set locally: User=your-username
+ExecStart=%h/scripts/system/fetch-emails.sh
```

`%h` is the systemd home-directory specifier for the configured `User=`.

## Test plan
- [ ] `grep -r 'zhiyu\|Users/' wezterm/` — no matches
- [ ] `grep 'home/stanfish' sway/ linux/services/` — no matches
- [ ] Sway starts with wallpaper after symlinking `~/.config/sway/wallpaper.jpeg`
- [ ] WezTerm starts with background after symlinking `~/.config/wezterm/background.jpg`

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4QrY2pRwq18cdRH5WJ5jt)_