### PR TITLE
fix: document machine-specific hwmon path in i3status cpu_temperature

### DIFF
--- a/gentoo/configs-TF-X220/home-stan/dot-config/i3status/config
+++ b/gentoo/configs-TF-X220/home-stan/dot-config/i3status/config
@@ -36,6 +36,8 @@ battery 0 {
 
 cpu_temperature 0 {
    format = "T: %degrees °C"
+   # hwmon index is kernel-assigned and machine-specific; verify with:
+   # cat /sys/class/hwmon/hwmon*/name
    path = "/sys/class/hwmon/hwmon4/temp1_input"
 }
 


### PR DESCRIPTION
Closes #84

The `hwmon4` index in the `cpu_temperature` block is assigned by the kernel at boot and can differ between machines or kernel versions. A silent wrong index causes i3status to show no temperature.

## Change

Added two-line comment pointing to the verification command:

```diff
 cpu_temperature 0 {
    format = "T: %degrees °C"
+   # hwmon index is kernel-assigned and machine-specific; verify with:
+   # cat /sys/class/hwmon/hwmon*/name
    path = "/sys/class/hwmon/hwmon4/temp1_input"
 }
```

## Why not a different fix

- A udev symlink (option 1 from #84) requires machine-specific setup outside the repo.
- A `general` script block with `sensors` (option 3) requires lm_sensors and changes behavior.
- The comment (option 2) is zero-risk and makes the portability requirement explicit at point of use.

## Test plan
- [ ] `i3status` still starts without errors
- [ ] Comment visible when deploying to a new machine as a reminder to verify the hwmon index

---
_Generated by [Claude Code](https://claude.ai/code/session_01AfWcTxmb8nkFEXFJu7CkvH)_