### PR TITLE
fix: remove stale WezTerm AppImage functions from hpc/.bashrc

### DIFF
--- a/hpc/.bashrc
+++ b/hpc/.bashrc
@@ -55,17 +55,7 @@ export PATH=$PATH:$HOME/go/bin
 function today() {
 	date +%Y-%m-%d
 }
-function imgcat() {
-	~/WezTerm-20221119-145034-49b9839f-Ubuntu18.04.AppImage imgcat "$1"
-}
 alias icat="kitten icat"
-function fzf-img() {
-	local width="${1:-auto}"
-	fzf --preview "case {} in 
-		*.png|*.jpg|*.tif) ~/WezTerm-20221119-145034-49b9839f-Ubuntu18.04.AppImage imgcat --width $width {} ;;
-		*) echo not image ;;
-	esac" --preview-window='down'
-}
 function fzf-kitty-img() {
 	local width="${1:-auto}"
 	local height="${2:-auto}"


### PR DESCRIPTION
Closes #89

`imgcat()` and `fzf-img()` both hardcoded a specific 2022 WezTerm AppImage filename (`WezTerm-20221119-145034-49b9839f-Ubuntu18.04.AppImage`) that silently fails on any machine that doesn't have that exact file at `~/`. Both functions are now superseded by equivalents added in the May 26 "render images in tmux using kitty ssh" commit:

- `imgcat()` → replaced by `alias icat="kitten icat"` (already present)
- `fzf-img()` → replaced by `fzf-kitty-img()` (already present)

## Change

```diff
-function imgcat() {
-	~/WezTerm-20221119-145034-49b9839f-Ubuntu18.04.AppImage imgcat "$1"
-}
 alias icat="kitten icat"
-function fzf-img() {
-	local width="${1:-auto}"
-	fzf --preview "case {} in
-		*.png|*.jpg|*.tif) ~/WezTerm-20221119-145034-49b9839f-Ubuntu18.04.AppImage imgcat --width $width {} ;;
-		*) echo not image ;;
-	esac" --preview-window='down'
-}
 function fzf-kitty-img() {
```

## Test plan
- [ ] `icat <image>` displays image via kitty on HPC
- [ ] `fzf-kitty-img` previews images correctly
- [ ] No references to WezTerm AppImage remain in hpc/.bashrc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ea5LV3fE5Sc415UN633Ugr)_