### PR TITLE
fix: use /etc/NIXOS to detect NixOS in detect_package_manager

### DIFF
--- a/linux/lib/common.sh
+++ b/linux/lib/common.sh
@@ -85,7 +85,7 @@ detect_package_manager() {
         echo "pacman"
     elif command_exists dnf; then
         echo "dnf"
-    elif command_exists nix; then
+    elif [[ -f /etc/NIXOS ]]; then
         echo "nix"
     else
         echo "unknown"
@@ -150,7 +150,7 @@ install_packages() {
 
 # Check if the current script is being sourced
 is_sourced() {
-    [[ "${BASH_SOURCE[1]}" != "${0}" ]]
+    [[  "${BASH_SOURCE[1]}" != "${0}" ]]
 }
 
 # Backup functionality


### PR DESCRIPTION
Closes #93\n\n## Problem\n\n`command_exists nix` is true on **any** system with the Nix package manager installed — Ubuntu, Arch, Fedora, etc. — not just NixOS. Introduced by the "nixos route update" commit (57cb03a), this causes `install_packages()` and `update_system()` to silently skip with a misleading \"NixOS detected\" message on Nix-enabled non-NixOS machines.\n\n## Fix\n\n```diff\n-    elif command_exists nix; then\n+    elif [[ -f /etc/NIXOS ]]; then\n         echo \"nix\"\n```\n\n`/etc/NIXOS` is created by the NixOS installer and is present only on NixOS. It is the canonical shell-script way to distinguish NixOS from other systems that happen to have `nix` installed.\n\n## Test plan\n- [ ] On NixOS: `detect_package_manager` returns `nix`; `install_packages` prints skip message\n- [ ] On Ubuntu/Arch with `nix` daemon installed: `detect_package_manager` returns `apt`/`pacman`; packages install normally\n- [ ] `grep 'command_exists nix' linux/lib/common.sh` — no matches

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDiJ3Qpok2SM3zRwojjbCs)_