### PR TITLE
fix: update Julia from 1.12.0-beta1 to stable 1.12 channel in hpc/.bashrc

### DIFF
--- a/hpc/.bashrc
+++ b/hpc/.bashrc
@@ -129,8 +129,8 @@ export NVM_DIR="$HOME/.nvm"
 #----------julia----------
 # note that this will be the julia used by juliapkg
 # 1.12 solves a Donwload.jl issue that prevents julia project creation on hpc
-juliaup default 1.12.0-beta1
-export PYTHON_JULIAPKG_EXE="$HOME/.julia/juliaup/julia-1.12.0-beta1+0.x64.linux.gnu/bin/julia"
+juliaup default 1.12
+export PYTHON_JULIAPKG_EXE="$HOME/.juliaup/bin/julia"
 
 #----------R----------
 # R is stupid


### PR DESCRIPTION
Closes #95

## Problem

`juliaup default 1.12.0-beta1` pins a beta that has since gone stable. The beta channel no longer receives updates, so the version is effectively frozen.

`PYTHON_JULIAPKG_EXE` hardcodes a version-specific path into juliaup's download cache:
```
$HOME/.julia/juliaup/julia-1.12.0-beta1+0.x64.linux.gnu/bin/julia
```
This path will silently break whenever juliaup manages a new installation (e.g. after `juliaup update`).

## Fix

```diff
-juliaup default 1.12.0-beta1
-export PYTHON_JULIAPKG_EXE="$HOME/.julia/juliaup/julia-1.12.0-beta1+0.x64.linux.gnu/bin/julia"
+juliaup default 1.12
+export PYTHON_JULIAPKG_EXE="$HOME/.juliaup/bin/julia"
```

- `juliaup default 1.12` pins to the stable 1.12 channel and automatically tracks 1.12.x patch releases.
- `$HOME/.juliaup/bin/julia` is the stable juliaup shim — it always resolves to whatever `juliaup default` is set to, so no path ever goes stale.

## Test plan
- [ ] `juliaup status` on HPC shows 1.12 as default
- [ ] `julia --version` returns a 1.12.x stable release
- [ ] `python -c "import juliapkg; juliapkg.ensure()"` resolves to the 1.12 shim

---
https://claude.ai/code/session_01WTBhRsoaG6vjkLiS3ofHpj

---
_Generated by [Claude Code](https://claude.ai/code/session_01WTBhRsoaG6vjkLiS3ofHpj)_