### PR TITLE
fix: update Julia from 1.12.0-beta1 to stable 1.12 channel in hpc/.bashrc

### DIFF
--- a/hpc/.bashrc
+++ b/hpc/.bashrc
@@ -77,7 +77,7 @@ function fzf-kitty-img() {
 
 # >>> conda initialize >>>
 # !! Contents within this block are managed by 'conda init' !!
-__conda_setup="$('/sw/pkgs/arc/python3.11-anaconda/2024.02-1/bin/conda' 'shell.bash' 'hook' 2> /dev/null)"
+__conda_setup="$(\'/sw/pkgs/arc/python3.11-anaconda/2024.02-1/bin/conda\' \'shell.bash\' \'hook\' 2> /dev/null)"
 if [ $? -eq 0 ]; then
     eval "$__conda_setup"
 else
@@ -129,8 +129,8 @@ export NVM_DIR="$HOME/.nvm"
 #----------julia----------
 # note that this will be the julia used by juliapkg
 # 1.12 solves a Donwload.jl issue that prevents julia project creation on hpc
-juliaup default 1.12.0-beta1
-export PYTHON_JULIAPKG_EXE="$HOME/.julia/juliaup/julia-1.12.0-beta1+0.x64.linux.gnu/bin/julia"
+juliaup default 1.12
+export PYTHON_JULIAPKG_EXE="$HOME/.juliaup/bin/julia"
 
 #----------R----------
 # R is stupid


### PR DESCRIPTION
Closes #95\n\n## Problem\n\n`juliaup default 1.12.0-beta1` pins a beta that has since gone stable. The beta channel no longer receives updates.\n\n`PYTHON_JULIAPKG_EXE` hardcodes a version-specific path into juliaup's cache:\n```\n$HOME/.julia/juliaup/julia-1.12.0-beta1+0.x64.linux.gnu/bin/julia\n```\nThis path silently breaks whenever juliaup manages a new installation (e.g. after `juliaup update`).\n\n## Fix\n\n```diff\n-juliaup default 1.12.0-beta1\n-export PYTHON_JULIAPKG_EXE=\"$HOME/.julia/juliaup/julia-1.12.0-beta1+0.x64.linux.gnu/bin/julia\"\n+juliaup default 1.12\n+export PYTHON_JULIAPKG_EXE=\"$HOME/.juliaup/bin/julia\"\n```\n\n- `juliaup default 1.12` pins to the stable 1.12 channel and automatically tracks 1.12.x patch releases.\n- `$HOME/.juliaup/bin/julia` is the stable juliaup shim — it always resolves to whatever `juliaup default` is set to, so no version-specific path ever goes stale.\n\n## Test plan\n- [ ] `juliaup status` on HPC shows 1.12 as default\n- [ ] `julia --version` returns a 1.12.x stable release\n- [ ] `python -c \"import juliapkg; juliapkg.ensure()\"` resolves to the 1.12 shim

---
_Generated by [Claude Code](https://claude.ai/code/session_01NoaAZCHYwMizPKg9H7iGcW)_