### PR TITLE
fix: remove stale WezTerm AppImage functions and update Julia to stable 1.12

### DIFF
--- a/hpc/.bashrc
+++ b/hpc/.bashrc
@@ -55,17 +55,7 @@ export PATH=$PATH:$HOME/go/bin
 function today() {
 	date +%Y-%m-%d
 }
-function imgcat() {
-	~/WezTerm-20221119-145034-49b9839f-Ubuntu18.04.AppImage imgcat "$1"
-}
 alias icat="kitten icat"
-function fzf-img() {
-	local width="${1:-auto}"
-	fzf --preview "case {} in 
-		*.png|*.jpg|*.tif) ~/WezTerm-20221119-145034-49b9839f-Ubuntu18.04.AppImage imgcat --width $width {} ;;
-		*) echo not image ;;
-	esac" --preview-window='down'
-}
 function fzf-kitty-img() {
 	local width="${1:-auto}"
 	local height="${2:-auto}"
@@ -129,8 +119,8 @@ export NVM_DIR="$HOME/.nvm"
 #----------julia----------
 # note that this will be the julia used by juliapkg
 # 1.12 solves a Donwload.jl issue that prevents julia project creation on hpc
-juliaup default 1.12.0-beta1
-export PYTHON_JULIAPKG_EXE="$HOME/.julia/juliaup/julia-1.12.0-beta1+0.x64.linux.gnu/bin/julia"
+juliaup default 1.12
+export PYTHON_JULIAPKG_EXE="$HOME/.juliaup/bin/julia"
 
 #----------R----------
 # R is stupid


### PR DESCRIPTION
Closes #95, closes #100

## Changes

### Remove stale WezTerm AppImage functions (fixes #100)

`imgcat()` and `fzf-img()` both hardcode a 2022 WezTerm AppImage filename that will silently fail on any session without that exact binary at `~/`:

```bash
# removed
function imgcat() {
    ~/WezTerm-20221119-145034-49b9839f-Ubuntu18.04.AppImage imgcat "$1"
}
function fzf-img() {
    ...~/WezTerm-20221119-145034-49b9839f-Ubuntu18.04.AppImage imgcat...
}
```

Their kitty replacements already exist in the same file — `alias icat="kitten icat"` and `fzf-kitty-img()` — so the old functions are just dead code.

### Update Julia from beta pin to stable 1.12 channel (fixes #95)

```diff
-juliaup default 1.12.0-beta1
-export PYTHON_JULIAPKG_EXE="$HOME/.julia/juliaup/julia-1.12.0-beta1+0.x64.linux.gnu/bin/julia"
+juliaup default 1.12
+export PYTHON_JULIAPKG_EXE="$HOME/.juliaup/bin/julia"
```

- `juliaup default 1.12` tracks the stable 1.12.x channel and picks up patch releases automatically.
- `$HOME/.juliaup/bin/julia` is the stable juliaup shim — always resolves to whatever `juliaup default` is, so no version-specific path ever goes stale after a `juliaup update`.

## Test plan
- [ ] `juliaup status` on HPC shows `1.12` as default
- [ ] `julia --version` returns a 1.12.x stable release
- [ ] `kitten icat` works as the image display alias
- [ ] `fzf-kitty-img` previews images correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_01QjSMxnkjwGTRyjAEx2gFuR)_