### PR TITLE
fix: replace hardcoded /home/stanfish/ with $HOME in debian zshrc (juliaup, conda, ghcup)

### DIFF
--- a/zsh/debian/.zshrc
+++ b/zsh/debian/.zshrc
@@ -127,30 +127,30 @@ alias lta="eza --tree --level=2 -a --group-directories-first --icons=auto"
 
 # !! Contents within this block are managed by juliaup !!
 
-path=('/home/stanfish/.juliaup/bin' $path)
+path=("$HOME/.juliaup/bin" $path)
 export PATH
 # Tab completion for juliaup and julia channel selection
-[ -f "/home/stanfish/.julia/juliaup/completions/zsh.zsh" ] && source "/home/stanfish/.julia/juliaup/completions/zsh.zsh"
+[ -f "$HOME/.julia/juliaup/completions/zsh.zsh" ] && source "$HOME/.julia/juliaup/completions/zsh.zsh"
 
 # <<< juliaup initialize <<<
 
 # >>> conda initialize >>>
 # !! Contents within this block are managed by 'conda init' !!
-__conda_setup="$('/home/stanfish/miniconda3/bin/conda' 'shell.zsh' 'hook' 2> /dev/null)"
+__conda_setup="$("$HOME/miniconda3/bin/conda" 'shell.zsh' 'hook' 2> /dev/null)"
 if [ $? -eq 0 ]; then
     eval "$__conda_setup"
 else
-    if [ -f "/home/stanfish/miniconda3/etc/profile.d/conda.sh" ]; then
-        . "/home/stanfish/miniconda3/etc/profile.d/conda.sh"
+    if [ -f "$HOME/miniconda3/etc/profile.d/conda.sh" ]; then
+        . "$HOME/miniconda3/etc/profile.d/conda.sh"
     else
-        export PATH="/home/stanfish/miniconda3/bin:$PATH"
+        export PATH="$HOME/miniconda3/bin:$PATH"
     fi
 fi
 unset __conda_setup
 # <<< conda initialize <<<
 
 
-[ -f "/home/stanfish/.ghcup/env" ] && . "/home/stanfish/.ghcup/env" # ghcup-env
+[ -f "$HOME/.ghcup/env" ] && . "$HOME/.ghcup/env" # ghcup-env
 
 [ -f ~/.fzf.zsh ] && source ~/.fzf.zsh
 


### PR DESCRIPTION
## Finding

The June-7 commit (`5d2131`) added `juliaup`, `conda init`, and `ghcup` blocks to `zsh/debian/.zshrc` by copy-pasting the verbatim output of those tools' init commands. These blocks contain hardcoded `/home/stanfish/` absolute paths. PR #105 (merged June 8) addressed other hardcoded paths in the file but missed these auto-generated sections.

Remaining hardcoded paths before this fix:
- `juliaup` block: `path=('/home/stanfish/.juliaup/bin' $path)` and the completion source
- `conda` block: conda executable path, `profile.d/conda.sh`, and fallback `PATH`
- `ghcup` env source line

## Fix

Replace every `/home/stanfish/` occurrence in those three blocks with `$HOME/`. The conda executable is now double-quoted inside `$(...)` so `$HOME` expands correctly at invocation time.

The hardcoded node version in `export PATH="$HOME/.local/share/mise/installs/node/26.2.0/bin:$PATH"` is **not** changed here — it is tracked separately in #106.

---
_Generated by [Claude Code](https://claude.ai/code/session_012UsR5EQdvD8cvL96EaS6aJ)_