### PR TITLE
fix: align codex bind-key to `o` in chezmoi tmux template, fix stale comments

### DIFF
--- a/home-chezmoi/dot_tmux.conf.tmpl
+++ b/home-chezmoi/dot_tmux.conf.tmpl
@@ -135,8 +135,9 @@ bind -T resize-mode Down resize-pane -D 5 \; switch-client -T resize-mode
 {{- end }}
 
 # Run codex in a pop-up window (todo: might be interesting to create a table to select what agent/program to run)
-# It uses md5sum to hash the session name, then resume/create claude session
-bind-key y run-shell '\
+# It uses md5sum to hash the session name, then resume/create codex session
+# claude is covered by set -g @plugin 'craftzdog/tmux-claude-session-manager'
+bind-key o run-shell '\
     SESSION="codex-$(echo #{pane_current_path} | md5sum | cut -c1-8)"; \
     tmux has-session -t "$SESSION" 2>/dev/null || \
     tmux new-session -d -s "$SESSION" -c "#{pane_current_path}" "codex"; \

--- a/tmux/linux/.tmux.conf
+++ b/tmux/linux/.tmux.conf
@@ -120,7 +120,7 @@ bind -T copy-mode-vi WheelUpPane select-pane \; send-keys -X -N 2 scroll-up
 bind -T copy-mode-vi WheelDownPane select-pane \; send-keys -X -N 2 scroll-down
 
 # Run codex code in a pop-up window (todo: might be interesting to create a table to select what agent/program to run)
-# It uses md5sum to hash the session name, then resume/create claude session
+# It uses md5sum to hash the session name, then resume/create codex session
 # claude is covered by set -g @plugin 'craftzdog/tmux-claude-session-manager'
 bind-key o run-shell '\
     SESSION="codex-$(echo #{pane_current_path} | md5sum | cut -c1-8)"; \


### PR DESCRIPTION
## Finding

The June-15 "tmux" commit (`39eb85c`) updated `home-chezmoi/dot_tmux.conf.tmpl` to:
1. Add the `craftzdog/tmux-claude-session-manager` plugin (handles claude on `y`)
2. Change the existing `bind-key y` to run `codex` instead of claude

But this creates a silent conflict: TPM runs plugins **after** all explicit config bindings, so the plugin's `y` binding for claude overwrites the explicit `bind-key y codex` entry. The codex popup would never actually launch from `y`.

`tmux/linux/.tmux.conf` got this right in the same batch of commits — it uses `bind-key o` for codex and lets the plugin own `y`.

Both files also had a stale comment saying "resume/create claude session" on the codex binding block.

## Fix

**`home-chezmoi/dot_tmux.conf.tmpl`**
- `bind-key y` → `bind-key o` (matches `tmux/linux/.tmux.conf`, avoids plugin conflict)
- Update comment from "claude session" to "codex session"
- Add note that claude is covered by the plugin

**`tmux/linux/.tmux.conf`**
- Update stale "resume/create claude session" comment to "codex session"

## Test plan
- [ ] `prefix + y` launches claude popup via plugin
- [ ] `prefix + o` launches codex popup in correct directory
- [ ] `prefix + g` launches lazygit popup (unchanged, verify no regression)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nev6cELgdHEuTkR1fKFD9y)_