### PR TITLE
fix: redact leaked WeatherAPI key in yasb/config.yaml

### DIFF
--- a/yasb/config.yaml
+++ b/yasb/config.yaml
@@ -569,7 +569,7 @@ widgets:
       options:
         label: "<span>{icon}</span> {temp}"
         label_alt: "{location}: Min {min_temp}, Max {max_temp}, Humidity {humidity}"
-        api_key: "222cdfe47c474d0c97d25040252206"
+        api_key: "your_weatherapi_key" # set locally: get a free key at https://www.weatherapi.com/
         update_interval: 600
         hide_decimal: true
         location: "Ann Arbor"


### PR DESCRIPTION
Closes #111

## Finding

`yasb/config.yaml` has had a live, plaintext `api_key` for the weather widget committed since `62dc144` (2026-05-16). It's a real WeatherAPI.com-style key sitting in a public repo.

## Fix

```diff
-        api_key: "222cdfe47c474d0c97d25040252206"
+        api_key: "your_weatherapi_key" # set locally: get a free key at https://www.weatherapi.com/
```

## Important

The key was already public — please rotate/revoke it at the provider and set the new key locally (not committed) after merging this.

## Test plan
- [ ] Old key revoked/rotated
- [ ] New key set locally, yasb weather widget still works
- [ ] `grep -n api_key yasb/config.yaml` shows only the placeholder


---
_Generated by [Claude Code](https://claude.ai/code/session_01VbsM932mMNMAym3MaEJ2qp)_