### PR TITLE
fix: redact still-live WeatherAPI key in yasb/config.yaml

### DIFF
--- a/yasb/config.yaml
+++ b/yasb/config.yaml
@@ -569,7 +569,7 @@ widgets:
       options:
         label: "<span>{icon}</span> {temp}"
         label_alt: "{location}: Min {min_temp}, Max {max_temp}, Humidity {humidity}"
-        api_key: "222cdfe47c474d0c97d25040252206"
+        api_key: "your_weatherapi_key" # set locally: get a free key at https://www.weatherapi.com/
         update_interval: 600
         hide_decimal: true
         location: "Ann Arbor"


### PR DESCRIPTION
Closes #111

## Finding

`yasb/config.yaml` has had a live, plaintext `api_key` for the weather widget committed since `62dc144` (2026-05-16). PR #112 already proposed this exact fix for issue #111, but it was closed without merging, and the key is still in `master` today.

## Fix

```diff
-        api_key: "222cdfe47c474d0c97d25040252206"
+        api_key: "your_weatherapi_key" # set locally: get a free key at https://www.weatherapi.com/
```

## Action needed from you

The key has been public for over a month — please rotate/revoke it at https://www.weatherapi.com/ and set the new one locally (not committed) after merging.

## Test plan
- [ ] Old key revoked/rotated
- [ ] New key set locally, yasb weather widget still works
- [ ] `grep -n api_key yasb/config.yaml` shows only the placeholder


---
_Generated by [Claude Code](https://claude.ai/code/session_011oWnReNMC8V2geucBpRcwE)_