### PR TITLE
fix: remove duplicate focus-events line in chezmoi tmux template

### DIFF
--- a/home-chezmoi/dot_tmux.conf.tmpl
+++ b/home-chezmoi/dot_tmux.conf.tmpl
@@ -106,8 +106,7 @@ set -g default-terminal "tmux-256color"
 set -sa terminal-features ',xterm-256color:RGB'
 set -sa terminal-overrides ',xterm-256color:Tc'
 
-# Related to terminal integraion
-set -g focus-events on
+# Related to terminal integration
 set -g allow-passthrough on
 
 # Pane base index (windows already set to 1 above)


### PR DESCRIPTION
Closes #130

## Finding

This weekly review covered the last 4 commits (`bc50fe9` ipython, `4ff0444` aerospace monitor, `bfced0f` ssh, `b57f6dd` update). No secrets/leaks were found, and the `ssh/config` additions and `aerospace.toml` monitor-assignment syntax (`monitor.secondary` is a documented AeroSpace built-in pattern) check out fine.

The one actionable item: `b57f6dd` added a second `set -g focus-events on` to `home-chezmoi/dot_tmux.conf.tmpl`, duplicating an existing one a few lines above (added earlier for vim/neovim autoread). Harmless (tmux just re-applies the same value) but dead config, plus the new comment had a typo ("integraion").

## Fix

```diff
-# Related to terminal integraion
-set -g focus-events on
+# Related to terminal integration
 set -g allow-passthrough on
```

## Test plan
- [ ] `grep -c 'focus-events on' home-chezmoi/dot_tmux.conf.tmpl` → 1
- [ ] `tmux source-file` the template still loads without error


---
_Generated by [Claude Code](https://claude.ai/code/session_015PvcsPDeeiqWEzkS69Bmj4)_