### PR TITLE
fix: sync ghostty/config and tmux/linux/.tmux.conf with chezmoi mirrors

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -10,7 +10,7 @@ split-divider-color = #000000
 # somehow shaders forces macos to use higher refresh rate on ghostty
 custom-shader = ./shader/cursor_blaze_tapered.glsl
 custom-shader = ./shader/cursor_vertical_lines.glsl
-custom-shader-animation = true
+custom-shader-animation = always
 background-opacity = 0.9
 background-blur = true
 

--- a/tmux/linux/.tmux.conf
+++ b/tmux/linux/.tmux.conf
@@ -106,6 +106,9 @@ set -g default-terminal "tmux-256color"
 set -sa terminal-features ',xterm-256color:RGB'
 set -sa terminal-overrides ',xterm-256color:Tc'
 
+# Related to terminal integration
+set -g allow-passthrough on
+
 # Pane base index (windows already set to 1 above)
 setw -g pane-base-index 1
 


### PR DESCRIPTION
Closes #132

## Finding

The repo keeps top-level reference copies of some dotfiles alongside the actual chezmoi-managed source in `home-chezmoi/` (wired up via `.chezmoiroot`). `b57f6dd` ("update") edited only the chezmoi copies and missed the mirrors:

1. `home-chezmoi/dot_config/ghostty/config`: `custom-shader-animation` `true` → `always` (intentional — `always` keeps the shader animation loop running while unfocused; see [Ghostty config reference](https://ghostty.org/docs/config/reference)). The mirror `ghostty/config` still had `true`.
2. `home-chezmoi/dot_tmux.conf.tmpl` gained `set -g allow-passthrough on`. The mirror `tmux/linux/.tmux.conf` was missing it — confirmed by diffing both files outside the explicitly-marked "machine specific" block, where they're otherwise identical.

## Fix

```diff
 # ghostty/config
-custom-shader-animation = true
+custom-shader-animation = always
```

```diff
 # tmux/linux/.tmux.conf
 set -sa terminal-overrides ',xterm-256color:Tc'

+# Related to terminal integration
+set -g allow-passthrough on
+
 # Pane base index (windows already set to 1 above)
```

No behavioral change beyond matching what's already deployed via chezmoi.

## Test plan
- [ ] `diff ghostty/config home-chezmoi/dot_config/ghostty/config` — no diff
- [ ] `tmux source-file tmux/linux/.tmux.conf` — loads without error

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_019BAb4U6BKEGavoY3vpKGeQ)_