### PR TITLE
fix: make clipboard thumbnail cache incremental and corruption-safe

### DIFF
--- a/quickshell/ClipboardPanel.qml
+++ b/quickshell/ClipboardPanel.qml
@@ -111,7 +111,10 @@ Scope {
       cliphist list | grep -F '[[ binary data' | while IFS= read -r line; do
         id="$(printf '%s' "$line" | cut -f1)"
         out="$1/$id.png"
-        [ -s "$out" ] || printf '%s' "$line" | cliphist decode > "$out"
+        if [ ! -s "$out" ]; then
+          tmp="$out.tmp"
+          printf '%s' "$line" | cliphist decode > "$tmp" && mv "$tmp" "$out" || rm -f "$tmp"
+        fi
         echo "$id"
       done
     `, "sh", root.thumbDir]
@@ -129,7 +132,15 @@ Scope {
 
   Process {
     id: pruneProc
-    command: ["sh", "-c", `rm -rf "$1"`, "sh", root.thumbDir]
+    command: ["sh", "-c", `
+      mkdir -p "$1"
+      live_ids="$(cliphist list | cut -f1 | sort -u)"
+      find "$1" -type f -name '*.tmp' -delete
+      find "$1" -type f -name '*.png' -print0 | while IFS= read -r -d '' file; do
+        id="$(basename "$file" .png)"
+        printf '%s\n' "$live_ids" | grep -Fxq "$id" || rm -f "$file"
+      done
+    `, "sh", root.thumbDir]
   }
 
   PanelWindow {


### PR DESCRIPTION
Closes #126

Supersedes #129 (Copilot's draft, same approach — merging this one since it applies cleanly against current master).

## Finding

`quickshell/ClipboardPanel.qml`'s `pruneProc` ran `rm -rf "$thumbDir"` on every panel close. `thumbProc`'s existence check (`[ -s "$out" ] || …`) was meant to skip already-decoded images, but since the whole directory was wiped on close, every reopen re-decoded **all** image entries from scratch regardless of how recently the panel was used. An interrupted decode could also leave a truncated `.png` that the existence check would then treat as valid.

## Fix

- **Atomic decode**: `thumbProc` now writes to `$out.tmp` and `mv`s into place, so a truncated/interrupted decode never leaves a corrupt file where the existence check looks.
- **Selective prune**: `pruneProc` now removes only `.png` thumbnails whose id is no longer present in `cliphist list`, plus any stray `.tmp` files — instead of deleting the whole cache directory.

```diff
-        [ -s "$out" ] || printf '%s' "$line" | cliphist decode > "$out"
+        if [ ! -s "$out" ]; then
+          tmp="$out.tmp"
+          printf '%s' "$line" | cliphist decode > "$tmp" && mv "$tmp" "$out" || rm -f "$tmp"
+        fi
```

```diff
-    command: ["sh", "-c", `rm -rf "$1"`, "sh", root.thumbDir]
+    command: ["sh", "-c", `
+      mkdir -p "$1"
+      live_ids="$(cliphist list | cut -f1 | sort -u)"
+      find "$1" -type f -name '*.tmp' -delete
+      find "$1" -type f -name '*.png' -print0 | while IFS= read -r -d '' file; do
+        id="$(basename "$file" .png)"
+        printf '%s\n' "$live_ids" | grep -Fxq "$id" || rm -f "$file"
+      done
+    `, "sh", root.thumbDir]
```

## Test plan
- [ ] Copy an image, open panel (decodes + shows thumbnail), close, reopen — thumbnail appears instantly without re-decoding
- [ ] Copy an image, delete it from cliphist, close panel — stale `.png` is pruned
- [ ] Kill the panel process mid-decode (simulate interruption) — no corrupt `.png` left behind, no `.tmp` litter after next prune

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_014CUvN9H2Ut11aYwkAvRF9k)_