### PR TITLE
fix: sync ghostty/config mirror with chezmoi clipboard settings

### DIFF
--- a/ghostty/config
+++ b/ghostty/config
@@ -28,3 +28,6 @@ keybind = super+shift+\=new_split:right
 keybind = super+shift+-=new_split:down
 keybind = super+k=close_surface
 keybind = super+alt+k=close_tab:this
+
+clipboard-read = allow
+clipboard-write = allow


### PR DESCRIPTION
Closes #136

## Finding

`6f8e6ab` ("update") added `clipboard-read = allow` / `clipboard-write = allow` to the chezmoi-managed source `home-chezmoi/dot_config/ghostty/config`, but the top-level reference mirror `ghostty/config` was left behind — the same drift pattern already fixed by #131 and #133.

## Fix

```diff
 keybind = super+alt+k=close_tab:this
+
+clipboard-read = allow
+clipboard-write = allow
```

No behavioral change (chezmoi only reads `home-chezmoi/`); this just keeps the reference mirror accurate.

## Test plan
- [ ] `diff ghostty/config home-chezmoi/dot_config/ghostty/config` — no diff

---
_Generated by Claude Code_

---
_Generated by [Claude Code](https://claude.ai/code/session_013M8DdzG1Ncvh92MdTsb4E7)_